### PR TITLE
Add scrolling to community ideas and balance roadmap layout

### DIFF
--- a/src/components/roadmap/FeatureSuggestionForm.tsx
+++ b/src/components/roadmap/FeatureSuggestionForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Lightbulb, Send, Loader2, Lock, ArrowRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -51,8 +52,8 @@ export const FeatureSuggestionForm = ({
   // Non-premium users see upgrade CTA
   if (!canSubmit) {
     return (
-      <Card className="border-border/50 bg-card/50">
-        <CardContent className="flex flex-col items-center justify-center py-6 px-4 text-center">
+      <Card className="border-border/50 bg-card/50 h-full">
+        <CardContent className="flex flex-col items-center justify-center py-6 px-4 text-center h-full">
           <div className="w-10 h-10 rounded-full bg-muted/50 flex items-center justify-center mb-3">
             <Lock className="w-5 h-5 text-muted-foreground" />
           </div>
@@ -71,10 +72,17 @@ export const FeatureSuggestionForm = ({
   }
 
   return (
-    <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger asChild>
-          <CardHeader className="cursor-pointer hover:bg-primary/5 transition-colors rounded-t-lg !flex !items-center !justify-center min-h-[180px] py-8">
+    <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent h-full flex flex-col">
+      <Collapsible
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        className="flex-1 flex flex-col"
+      >
+        <CollapsibleTrigger asChild className={cn(
+          "cursor-pointer hover:bg-primary/5 transition-colors rounded-t-lg !flex !items-center !justify-center py-8",
+          !isOpen ? "flex-1" : "min-h-[180px]"
+        )}>
+          <CardHeader>
             <div className="flex flex-col items-center justify-center text-center gap-2 w-full">
               <div className="p-2.5 rounded-lg bg-primary/10">
                 <Lightbulb className="w-5 h-5 text-primary" />

--- a/src/components/roadmap/FeatureSuggestionsList.tsx
+++ b/src/components/roadmap/FeatureSuggestionsList.tsx
@@ -10,7 +10,6 @@ import { FeatureSuggestion } from '@/hooks/useFeatureSuggestions';
 interface FeatureSuggestionsListProps {
   suggestions: FeatureSuggestion[];
   loading: boolean;
-  maxItems?: number;
 }
 
 const statusConfig = {
@@ -38,17 +37,14 @@ const statusConfig = {
 
 export const FeatureSuggestionsList = ({
   suggestions,
-  loading,
-  maxItems = 6
+  loading
 }: FeatureSuggestionsListProps) => {
   const [selectedSuggestion, setSelectedSuggestion] = useState<FeatureSuggestion | null>(null);
 
-  const displayedSuggestions = suggestions.slice(0, maxItems);
-
   if (loading) {
     return (
-      <Card className="border-border/50">
-        <CardContent className="flex items-center justify-center py-10 px-4">
+      <Card className="border-border/50 h-full">
+        <CardContent className="flex items-center justify-center py-10 px-4 h-full">
           <Loader2 className="w-6 h-6 animate-spin text-primary" />
         </CardContent>
       </Card>
@@ -57,8 +53,8 @@ export const FeatureSuggestionsList = ({
 
   if (suggestions.length === 0) {
     return (
-      <Card className="border-border/50">
-        <CardContent className="flex flex-col items-center justify-center py-10 px-4 text-center gap-2">
+      <Card className="border-border/50 h-full">
+        <CardContent className="flex flex-col items-center justify-center py-10 px-4 text-center gap-2 h-full">
           <MessageSquare className="w-10 h-10 text-muted-foreground/50" />
           <p className="text-sm font-medium text-muted-foreground">No community ideas yet</p>
           <p className="text-xs text-muted-foreground/70">Be the first to submit one!</p>
@@ -68,9 +64,9 @@ export const FeatureSuggestionsList = ({
   }
 
   return (
-    <div>
-      <Card className="border-border/50">
-        <CardHeader className="pb-3 text-center">
+    <div className="h-full">
+      <Card className="border-border/50 h-full flex flex-col">
+        <CardHeader className="pb-3 text-center flex-shrink-0">
           <CardTitle className="text-base md:text-lg flex flex-col items-center gap-2">
             <MessageSquare className="w-4 h-4 text-primary" />
             Recent Community Ideas
@@ -79,10 +75,10 @@ export const FeatureSuggestionsList = ({
             {suggestions.length} idea{suggestions.length !== 1 ? 's' : ''} submitted
           </CardDescription>
         </CardHeader>
-        <CardContent className="pt-0 px-0">
-          <ScrollArea className="max-h-[500px] px-6">
+        <CardContent className="pt-0 px-0 flex-1 min-h-0">
+          <ScrollArea className="h-full max-h-[600px] px-6">
             <div className="space-y-2 pb-4">
-              {displayedSuggestions.map((suggestion) => {
+              {suggestions.map((suggestion) => {
                 const status = statusConfig[suggestion.status];
                 const StatusIcon = status.icon;
 
@@ -113,12 +109,6 @@ export const FeatureSuggestionsList = ({
                   </button>
                 );
               })}
-
-              {suggestions.length > maxItems && (
-                <p className="text-xs text-center text-muted-foreground pt-2">
-                  +{suggestions.length - maxItems} more ideas
-                </p>
-              )}
             </div>
           </ScrollArea>
         </CardContent>

--- a/src/pages/Roadmap.tsx
+++ b/src/pages/Roadmap.tsx
@@ -284,7 +284,7 @@ const Roadmap = () => {
                 </p>
               </div>
 
-              <div className="grid gap-6 md:grid-cols-2 items-start">
+              <div className="grid gap-6 md:grid-cols-2">
                 {/* Submit Form */}
                 <FeatureSuggestionForm
                   canSubmit={canVote}
@@ -296,7 +296,6 @@ const Roadmap = () => {
                 <FeatureSuggestionsList
                   suggestions={suggestions}
                   loading={suggestionsLoading}
-                  maxItems={20}
                 />
               </div>
             </div>


### PR DESCRIPTION
The recent community ideas section on the roadmap page now features a scrollable list that displays all submitted ideas instead of a limited subset. Additionally, the layout has been improved to ensure that the "Submit Your Feature Idea" box and the "Recent Community Ideas" list are perfectly aligned in height, creating a more balanced and professional-looking interface. This was achieved by using CSS Grid stretching and ensuring components internally handle the available vertical space.

---
*PR created automatically by Jules for task [6458593496247467613](https://jules.google.com/task/6458593496247467613) started by @3rdeyeadvisors*