### PR TITLE
Add Admin Dashboard Button for Kevinguerrier.kg@gmail.com

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,6 +10,8 @@ import {
 import { useAuth } from "@/components/auth/AuthProvider";
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/contexts/CartContext";
+import { supabase } from "@/integrations/supabase/client";
+import { isAdminEmail } from "@/lib/admin";
 
 import {
   NavigationMenu,
@@ -24,6 +26,7 @@ const Navigation = () => {
   const { itemCount } = useCart();
   const [isOpen, setIsOpen] = useState(false);
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
   const location = useLocation();
   const { user, signOut } = useAuth();
   const { toast } = useToast();
@@ -33,6 +36,38 @@ const Navigation = () => {
     setIsOpen(false);
     setExpandedSection(null);
   }, [location.pathname]);
+
+  // Check admin status
+  useEffect(() => {
+    const checkAdmin = async () => {
+      if (!user) {
+        setIsAdmin(false);
+        return;
+      }
+
+      // Explicitly allow the requested admin email
+      if (isAdminEmail(user.email)) {
+        setIsAdmin(true);
+        return;
+      }
+
+      try {
+        const { data } = await supabase
+          .from('user_roles')
+          .select('role')
+          .eq('user_id', user.id)
+          .eq('role', 'admin')
+          .maybeSingle();
+
+        setIsAdmin(!!data);
+      } catch (error) {
+        console.error("Error checking admin status:", error);
+        setIsAdmin(false);
+      }
+    };
+
+    checkAdmin();
+  }, [user]);
 
   // Prevent body scroll when menu is open
   useEffect(() => {
@@ -222,6 +257,19 @@ const Navigation = () => {
               </Link>
               {user ? (
                 <div className="flex items-center gap-2">
+                  {isAdmin && (
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground hover:text-primary hidden lg:flex h-11"
+                    >
+                      <Link to="/admin" className="flex items-center space-x-2">
+                        <Shield className="w-4 h-4" />
+                        <span>Admin</span>
+                      </Link>
+                    </Button>
+                  )}
                   <Button
                     asChild
                     variant="ghost"
@@ -297,7 +345,16 @@ const Navigation = () => {
                     </div>
                   </div>
                   
-                  <div className="grid grid-cols-3 gap-2">
+                  <div className={`grid ${isAdmin ? 'grid-cols-4' : 'grid-cols-3'} gap-2`}>
+                    {isAdmin && (
+                      <Link
+                        to="/admin"
+                        className="flex flex-col items-center gap-1 p-3 rounded-xl bg-card/50 border border-border/50 hover:bg-card hover:border-primary/30 transition-all active:scale-95"
+                      >
+                        <Shield className="w-5 h-5 text-primary" />
+                        <span className="text-xs font-medium">Admin</span>
+                      </Link>
+                    )}
                     <Link 
                       to="/profile"
                       className="flex flex-col items-center gap-1 p-3 rounded-xl bg-card/50 border border-border/50 hover:bg-card hover:border-primary/30 transition-all active:scale-95"

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { Loader2 } from 'lucide-react';
+import { isAdminEmail } from '@/lib/admin';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -39,6 +40,13 @@ const ProtectedRoute = ({
       }
 
       try {
+        // Explicitly allow the requested admin email
+        if (isAdminEmail(user.email)) {
+          setHasRole(true);
+          setRoleCheckDone(true);
+          return;
+        }
+
         const { data: roles, error } = await supabase
           .from('user_roles')
           .select('role')

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,5 @@
+export const ADMIN_EMAIL = 'kevinguerrier.kg@gmail.com';
+
+export const isAdminEmail = (email: string | undefined | null) => {
+  return email?.toLowerCase() === ADMIN_EMAIL;
+};

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -16,6 +16,7 @@ import EmailPreview from "@/components/admin/EmailPreview";
 import { TutorialCourseParticipation } from "@/components/admin/TutorialCourseParticipation";
 import CommissionsManager from "@/components/admin/CommissionsManager";
 import RoadmapManager from "@/components/admin/RoadmapManager";
+import { isAdminEmail } from "@/lib/admin";
 
 const AdminDashboard = () => {
   const navigate = useNavigate();
@@ -40,6 +41,13 @@ const AdminDashboard = () => {
 
       // Only re-check if the user ID has changed
       if (checkedUserId === user.id) {
+        return;
+      }
+
+      // Explicitly allow the requested admin email
+      if (isAdminEmail(user.email)) {
+        setCheckedUserId(user.id);
+        setIsAdmin(true);
         return;
       }
 

--- a/src/pages/AdminStoreDashboard.tsx
+++ b/src/pages/AdminStoreDashboard.tsx
@@ -16,6 +16,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Loader2, Plus, Trash2, Edit, Package, ShoppingCart, Tag, Download, Mail } from "lucide-react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
+import { isAdminEmail } from "@/lib/admin";
 
 const AdminStoreDashboard = () => {
   const navigate = useNavigate();
@@ -50,6 +51,13 @@ const AdminStoreDashboard = () => {
       
       if (!user) {
         navigate("/auth");
+        return;
+      }
+
+      // Explicitly allow the requested admin email
+      if (isAdminEmail(user.email)) {
+        setIsAdmin(true);
+        loadDashboardData();
         return;
       }
 

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -11,6 +11,7 @@ import { MerchandiseCard } from "@/components/store/MerchandiseCard";
 import { NFTStoreCard } from "@/components/store/NFTStoreCard";
 import { usePullToRefresh } from "@/hooks/usePullToRefresh";
 import { PullToRefreshIndicator } from "@/components/ui/pull-to-refresh";
+import { isAdminEmail } from "@/lib/admin";
 
 type StoreCategory = 'merchandise' | 'digital';
 
@@ -111,6 +112,12 @@ const Store = () => {
     const checkAdminRole = async () => {
       if (!user) {
         setIsAdmin(false);
+        return;
+      }
+
+      // Explicitly allow the requested admin email
+      if (isAdminEmail(user.email)) {
+        setIsAdmin(true);
         return;
       }
 


### PR DESCRIPTION
Implemented an "Admin" button in the navigation for the user Kevinguerrier.kg@gmail.com.
The logic is centralized in a new utility `src/lib/admin.ts` to ensure maintainability.
All relevant admin routes and pages now explicitly recognize this email as authorized, ensuring a seamless transition from the Lovable interface to the native platform dashboard.

---
*PR created automatically by Jules for task [15184705696243397149](https://jules.google.com/task/15184705696243397149) started by @3rdeyeadvisors*