### PR TITLE
Remove GitHub social links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Mail, Github, Instagram } from 'lucide-react';
+import { Mail, Instagram } from 'lucide-react';
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
@@ -25,7 +25,6 @@ const Footer = () => {
   const socialLinks = [
     { icon: Mail, href: 'mailto:info@the3rdeyeadvisors.com', label: 'Email' },
     { icon: Instagram, href: 'https://instagram.com/3rdeyeadvisors', label: 'Instagram' },
-    { icon: Github, href: 'https://github.com/3rdeyeadvisors', label: 'GitHub' },
   ];
 
   return (

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Mail, MessageSquare, Send, Globe, Twitter, Github } from "lucide-react";
+import { Mail, MessageSquare, Send, Globe, Twitter } from "lucide-react";
 import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import NewsletterSignup from "@/components/NewsletterSignup";
@@ -298,16 +298,6 @@ const Contact = () => {
                   </a>
                 </Button>
                 
-                <Button 
-                  variant="outline" 
-                  className="w-full justify-start font-consciousness"
-                  asChild
-                >
-                  <a href="https://github.com/3rdeyeadvisors" target="_blank" rel="noopener noreferrer" className="flex items-center">
-                    <Github className="w-4 h-4 mr-3" />
-                    Open Source Resources
-                  </a>
-                </Button>
               </div>
             </Card>
 


### PR DESCRIPTION
This change removes the GitHub social media links from both the footer and the contact page as requested by the user. Unused imports for the Github icon from lucide-react were also removed to keep the codebase clean. Verification included TypeScript checks, grep for remaining references, and visual confirmation via Playwright screenshots.

---
*PR created automatically by Jules for task [13278985417806974773](https://jules.google.com/task/13278985417806974773) started by @3rdeyeadvisors*