### PR TITLE
Roadmap Card Layout Fix + Legacy Token Cleanup

### DIFF
--- a/src/components/roadmap/RoadmapCard.tsx
+++ b/src/components/roadmap/RoadmapCard.tsx
@@ -29,7 +29,7 @@ interface RoadmapCardProps {
 const statusConfig = {
   proposed: {
     label: 'Proposed',
-    className: 'bg-muted text-muted-foreground border-muted',
+    className: 'bg-white/8 text-white/50 border-white/15',
   },
   in_progress: {
     label: 'In Progress',
@@ -223,7 +223,7 @@ export const RoadmapCard = ({
   return (
     <>
       <div
-        className="bg-white/3 border border-white/8 rounded-2xl p-5 hover:border-violet-500/20 transition-all cursor-pointer h-full flex flex-col group"
+        className="bg-white/3 border border-white/8 rounded-2xl p-5 hover:border-violet-500/20 transition-all cursor-pointer h-full flex flex-col group overflow-hidden"
         onClick={handleCardClick}
       >
         <div className="flex items-start justify-between gap-4 mb-4">
@@ -250,12 +250,12 @@ export const RoadmapCard = ({
             </p>
             <p className="font-body text-[10px] uppercase tracking-widest text-white/40">Net Votes</p>
           </div>
-          <div className="flex-1 max-w-[160px]">
+          <div className="flex-1 min-w-0">
             <VotingButtons />
           </div>
         </div>
 
-        <div className="mt-4 pt-4 border-t border-white/5 flex items-center justify-between">
+        <div className="mt-4 pt-4 border-t border-white/5 flex flex-wrap items-center justify-between gap-2">
           <VoteWeightBadge />
           {!isCompleted && timeRemaining && (
             <span className={`font-body text-[10px] uppercase tracking-widest ${timeRemaining.urgent ? 'text-amber-400' : 'text-white/40'}`}>
@@ -282,10 +282,10 @@ export const RoadmapCard = ({
               {!isCompleted && timeRemaining && (
                 <div className={`flex items-center gap-1 text-xs ${
                   timeRemaining.expired
-                    ? 'text-muted-foreground'
+                    ? 'text-white/50'
                     : timeRemaining.urgent
                       ? 'text-amber-400'
-                      : 'text-muted-foreground'
+                      : 'text-white/50'
                 }`}>
                   {timeRemaining.urgent && !timeRemaining.expired ? (
                     <AlertTriangle className="w-3 h-3" />
@@ -301,18 +301,18 @@ export const RoadmapCard = ({
           <div className="space-y-4 mt-4">
             {/* Full Description */}
             {description && (
-              <DialogDescription className="text-sm text-foreground/80 leading-relaxed whitespace-pre-wrap">
+              <DialogDescription className="text-sm text-white/70 leading-relaxed whitespace-pre-wrap">
                 {description}
               </DialogDescription>
             )}
 
             {/* Vote Progress */}
-            <div className="space-y-2 p-4 rounded-lg bg-muted/30 border border-border/50">
+            <div className="space-y-2 p-4 rounded-lg bg-white/5 border border-white/8">
               <div className="flex items-center justify-between text-sm">
-                <span className="text-muted-foreground">Current Support</span>
+                <span className="text-white/50">Current Support</span>
                 <span className="font-medium">
                   <span className="text-emerald-400">+{yesVotes} yes</span>
-                  <span className="text-muted-foreground mx-2">|</span>
+                  <span className="text-white/50 mx-2">|</span>
                   <span className="text-red-400">-{noVotes} no</span>
                 </span>
               </div>
@@ -328,7 +328,7 @@ export const RoadmapCard = ({
             <div className="flex items-center justify-center gap-3 flex-wrap">
               <VoteWeightBadge />
               {userVoteType && (
-                <span className="text-sm text-muted-foreground">
+                <span className="text-sm text-white/50">
                   Your vote: <span className={userVoteType === 'yes' ? 'text-emerald-400' : 'text-red-400'}>
                     {userVoteType === 'yes' ? 'Yes (Support)' : 'No (Oppose)'}
                   </span>

--- a/src/pages/Roadmap.tsx
+++ b/src/pages/Roadmap.tsx
@@ -101,7 +101,7 @@ const Roadmap = () => {
                 </div>
               ) : !canVote ? (
                 <div className="pt-2">
-                  <p className="text-xs sm:text-sm text-muted-foreground mb-2">
+                  <p className="font-body text-xs sm:text-sm text-white/50 mb-2">
                     Upgrade to Annual or join Founding 33 to unlock voting
                   </p>
                   <Button asChild variant="outline" size="sm">
@@ -169,7 +169,7 @@ const Roadmap = () => {
                 </p>
               </div>
             ) : (
-              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 items-stretch">
                 {filteredItems.map((item) => (
                   <RoadmapCard
                     key={item.id}
@@ -204,7 +204,7 @@ const Roadmap = () => {
                 <h2 className="text-xl md:text-2xl font-consciousness font-bold mb-2">
                   Have a Feature Idea?
                 </h2>
-                <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                <p className="font-body text-sm text-white/50 max-w-md mx-auto">
                   Premium members can submit ideas for consideration. Popular suggestions may be promoted to the public roadmap.
                 </p>
               </div>


### PR DESCRIPTION
This PR addresses layout issues on the Roadmap page and its components, particularly on mobile devices. It also continues the migration from legacy theme tokens to the new standardized opacity-based white tokens.

Key changes:
- Added `overflow-hidden` to `RoadmapCard` to prevent content escaping.
- Improved flexbox behavior on mobile for voting buttons and footer rows in `RoadmapCard`.
- Enabled `items-stretch` on the `Roadmap` page grid to ensure all cards in a row have equal height.
- Replaced legacy tokens (`bg-muted`, `border-border`, `text-muted-foreground`, `text-foreground/80`) with `bg-white/5`, `border-white/8`, `text-white/50`, and `text-white/70` in the `RoadmapCard` Dialog.
- Updated the `proposed` status badge styling to align with the new design standards.
- Updated paragraph styling on the `Roadmap` page to use `font-body` and `text-white/50`.

---
*PR created automatically by Jules for task [6491653537537507862](https://jules.google.com/task/6491653537537507862) started by @3rdeyeadvisors*