### PR TITLE
Audio — Remove Listen from Quiz Modules + Professional Text Preprocessing

### DIFF
--- a/src/components/audio/AudioPlayer.tsx
+++ b/src/components/audio/AudioPlayer.tsx
@@ -7,39 +7,113 @@ interface AudioPlayerProps {
   onClose: () => void;
 }
 
-// Strip markdown syntax to get clean readable text
-const stripMarkdown = (text: string): string => {
-  return text
-    .replace(/#{1,6}\s+/g, '') // headers
-    .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
-    .replace(/\*([^*]+)\*/g, '$1') // italic
-    .replace(/`([^`]+)`/g, '$1') // inline code
-    .replace(/```[\s\S]*?```/g, '') // code blocks
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // links
-    .replace(/^\s*[-*+]\s+/gm, '') // bullet points
-    .replace(/^\s*\d+\.\s+/gm, '') // numbered lists
-    .replace(/^\s*>\s+/gm, '') // blockquotes
-    .replace(/\[COMPONENT:[^\]]+\][\s\S]*?\}/g, '') // custom components
-    .replace(/---/g, '') // dividers
-    .replace(/\n{3,}/g, '\n\n') // excess newlines
-    .trim();
+// Emoji unicode ranges to strip
+const EMOJI_REGEX = /[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F1FF}\u{1F200}-\u{1F2FF}\u{1F004}\u{1F0CF}\u{FE0F}\u{20E3}]/gu;
+
+// Transform raw content into natural spoken audio script
+const prepareForSpeech = (text: string): string => {
+  let result = text;
+
+  // 1. Strip emojis completely
+  result = result.replace(EMOJI_REGEX, '');
+
+  // 2. Remove custom component tags like [COMPONENT:KEY_TAKEAWAY] { ... }
+  result = result.replace(/\[COMPONENT:[^\]]+\][\s\S]*?\}/g, '');
+
+  // 3. Transform markdown headers into spoken transitions
+  result = result.replace(/^#{1}\s+(.+)$/gm, 'Section: $1.');
+  result = result.replace(/^#{2}\s+(.+)$/gm, '$1.');
+  result = result.replace(/^#{3,6}\s+(.+)$/gm, '$1.');
+
+  // 4. Transform bold text - read naturally without asterisks
+  result = result.replace(/\*\*([^*]+)\*\*/g, '$1');
+  result = result.replace(/\*([^*]+)\*/g, '$1');
+
+  // 5. Transform bullet point lists into natural sentences
+  result = result.replace(/^[\s]*[-*+•]\s+(.+)$/gm, '$1.');
+
+  // 6. Transform numbered lists
+  result = result.replace(/^[\s]*(\d+)\.\s+(.+)$/gm, 'Point $1: $2.');
+
+  // 7. Strip inline code and code blocks
+  result = result.replace(/```[\s\S]*?```/g, '');
+  result = result.replace(/`([^`]+)`/g, '$1');
+
+  // 8. Strip markdown links but keep the text
+  result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+
+  // 9. Strip blockquotes
+  result = result.replace(/^>\s+/gm, '');
+
+  // 10. Strip horizontal rules
+  result = result.replace(/^[-*_]{3,}$/gm, '');
+
+  // 11. Strip HTML tags if any
+  result = result.replace(/<[^>]+>/g, '');
+
+  // 12. Strip special characters that don't belong in speech
+  result = result.replace(/[#*_~|\\]/g, '');
+
+  // 13. Fix common abbreviations that TTS reads awkwardly
+  result = result.replace(/\bDeFi\b/g, 'De-Fi');
+  result = result.replace(/\bAPY\b/g, 'A.P.Y.');
+  result = result.replace(/\bAPR\b/g, 'A.P.R.');
+  result = result.replace(/\bTVL\b/g, 'T.V.L.');
+  result = result.replace(/\bDAO\b/g, 'D.A.O.');
+  result = result.replace(/\bNFT\b/g, 'N.F.T.');
+  result = result.replace(/\bDEX\b/g, 'D.E.X.');
+  result = result.replace(/\bCEX\b/g, 'C.E.X.');
+  result = result.replace(/\bRWA\b/g, 'R.W.A.');
+  result = result.replace(/\bAML\b/g, 'A.M.L.');
+  result = result.replace(/\bKYC\b/g, 'K.Y.C.');
+
+  // 14. Convert % to "percent" for natural reading
+  result = result.replace(/(\d+)%/g, '$1 percent');
+
+  // 15. Convert $ amounts
+  result = result.replace(/\$(\d[\d,]*)/g, '$1 dollars');
+
+  // 16. Clean up excessive whitespace and blank lines
+  result = result.replace(/\n{3,}/g, '\n\n');
+  result = result.replace(/[ \t]{2,}/g, ' ');
+
+  // 17. Trim
+  return result.trim();
 };
 
-// Split text into readable chunks (sentences)
-const splitIntoChunks = (text: string): string[] => {
-  const sentences = text.match(/[^.!?]+[.!?]+/g) || [text];
+// Split into natural spoken paragraphs and sentences
+const splitIntoSpeechChunks = (text: string): string[] => {
+  // Split on paragraph breaks first
+  const paragraphs = text.split(/\n\n+/).filter(p => p.trim().length > 0);
+
   const chunks: string[] = [];
-  let current = '';
-  for (const sentence of sentences) {
-    if ((current + sentence).length > 200) {
-      if (current) chunks.push(current.trim());
-      current = sentence;
-    } else {
-      current += sentence;
+
+  for (const paragraph of paragraphs) {
+    const clean = paragraph.trim();
+    if (!clean) continue;
+
+    // If paragraph is short enough, keep it as one chunk
+    if (clean.length <= 300) {
+      chunks.push(clean);
+      continue;
     }
+
+    // Otherwise split on sentence boundaries
+    const sentences = clean.match(/[^.!?]+[.!?]+[\s]*/g) || [clean];
+    let current = '';
+
+    for (const sentence of sentences) {
+      if ((current + sentence).length > 300) {
+        if (current.trim()) chunks.push(current.trim());
+        current = sentence;
+      } else {
+        current += sentence;
+      }
+    }
+    if (current.trim()) chunks.push(current.trim());
   }
-  if (current) chunks.push(current.trim());
-  return chunks.filter(c => c.length > 0);
+
+  return chunks.filter(c => c.trim().length > 5);
 };
 
 const AudioPlayer = ({ text, title, onClose }: AudioPlayerProps) => {
@@ -53,11 +127,70 @@ const AudioPlayer = ({ text, title, onClose }: AudioPlayerProps) => {
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const chunksRef = useRef<string[]>([]);
   const isPlayingRef = useRef(false);
+  const voiceRef = useRef<SpeechSynthesisVoice | null>(null);
+  const [currentSection, setCurrentSection] = useState<string>('');
 
-  const cleanText = stripMarkdown(text);
+  const cleanText = prepareForSpeech(text);
+
+  // Select best available voice on mount
+  useEffect(() => {
+    const selectVoice = () => {
+      const voices = window.speechSynthesis.getVoices();
+      if (voices.length === 0) return;
+
+      // Priority order: prefer natural/neural English voices
+      const preferred = [
+        'Google US English',
+        'Google UK English Female',
+        'Microsoft Aria Online (Natural)',
+        'Microsoft Guy Online (Natural)',
+        'Samantha',
+        'Karen',
+        'Daniel',
+      ];
+
+      for (const name of preferred) {
+        const match = voices.find(v => v.name === name);
+        if (match) {
+          voiceRef.current = match;
+          return;
+        }
+      }
+
+      // Fallback: pick first English voice
+      const englishVoice = voices.find(v => v.lang.startsWith('en'));
+      if (englishVoice) voiceRef.current = englishVoice;
+    };
+
+    selectVoice();
+    // voices may not be loaded yet on first render
+    window.speechSynthesis.onvoiceschanged = selectVoice;
+
+    return () => {
+      window.speechSynthesis.onvoiceschanged = null;
+    };
+  }, []);
+
+  // Keepalive fix for iOS/Chrome speechSynthesis cutoff bug
+  useEffect(() => {
+    let keepAliveInterval: ReturnType<typeof setInterval> | null = null;
+
+    if (isPlaying) {
+      keepAliveInterval = setInterval(() => {
+        if (window.speechSynthesis.speaking && !window.speechSynthesis.paused) {
+          window.speechSynthesis.pause();
+          window.speechSynthesis.resume();
+        }
+      }, 10000); // every 10 seconds
+    }
+
+    return () => {
+      if (keepAliveInterval) clearInterval(keepAliveInterval);
+    };
+  }, [isPlaying]);
 
   useEffect(() => {
-    chunksRef.current = splitIntoChunks(cleanText);
+    chunksRef.current = splitIntoSpeechChunks(cleanText);
     return () => {
       window.speechSynthesis.cancel();
     };
@@ -71,10 +204,16 @@ const AudioPlayer = ({ text, title, onClose }: AudioPlayerProps) => {
       isPlayingRef.current = false;
       return;
     }
-    const utterance = new SpeechSynthesisUtterance(chunksRef.current[index]);
+    const chunk = chunksRef.current[index];
+    if (chunk.startsWith('Section:')) {
+      setCurrentSection(chunk.replace('Section:', '').replace('.', '').trim());
+    }
+
+    const utterance = new SpeechSynthesisUtterance(chunk);
     utterance.rate = speed;
     utterance.volume = isMuted ? 0 : 1;
     utterance.pitch = 1;
+    if (voiceRef.current) utterance.voice = voiceRef.current;
     utterance.onend = () => {
       if (isPlayingRef.current) {
         const next = index + 1;
@@ -165,7 +304,9 @@ const AudioPlayer = ({ text, title, onClose }: AudioPlayerProps) => {
         >
           <div className="flex items-center gap-2">
             <Volume2 className="w-4 h-4 text-violet-400" />
-            <span className="font-body text-xs text-white/60 truncate max-w-[200px] sm:max-w-xs">{title}</span>
+            <span className="font-body text-xs text-white/60 truncate max-w-[200px] sm:max-w-xs">
+              {currentSection ? `${title} — ${currentSection}` : title}
+            </span>
           </div>
           <div className="flex items-center gap-3">
             {isMinimized ? (

--- a/src/components/course/EnhancedContentPlayer.tsx
+++ b/src/components/course/EnhancedContentPlayer.tsx
@@ -426,13 +426,15 @@ export const EnhancedContentPlayer = ({
                 Quiz Available
               </Badge>
             )}
-            <button
-              onClick={() => setShowAudio(true)}
-              className="flex items-center gap-2 font-body text-xs text-white/50 hover:text-violet-400 transition-colors bg-white/5 hover:bg-white/8 border border-white/10 hover:border-violet-500/30 rounded-xl px-3 py-2"
-            >
-              <Volume2 className="w-3.5 h-3.5" />
-              Listen
-            </button>
+            {module.content.text && module.content.text.trim().length > 200 && (
+              <button
+                onClick={() => setShowAudio(true)}
+                className="flex items-center gap-2 font-body text-xs text-white/50 hover:text-violet-400 transition-colors bg-white/5 hover:bg-white/8 border border-white/10 hover:border-violet-500/30 rounded-xl px-3 py-2"
+              >
+                <Volume2 className="w-3.5 h-3.5" />
+                Listen
+              </button>
+            )}
           </div>
           
           <div className="flex items-center justify-center md:justify-end gap-1.5 sm:gap-2">
@@ -692,7 +694,7 @@ export const EnhancedContentPlayer = ({
           </div>
         )}
       </div>
-      {showAudio && module.content.text && (
+      {showAudio && module.content.text && module.content.text.trim().length > 200 && (
         <AudioPlayer
           text={module.content.text}
           title={module.title}


### PR DESCRIPTION
This PR improves the audio (text-to-speech) functionality across the platform.

Key changes:
1. **Conditional Visibility**: The 'Listen' button in `EnhancedContentPlayer.tsx` now only appears for modules with substantial text content (> 200 characters), hiding it for quiz-only or short intro modules.
2. **Professional Preprocessing**: Replaced basic markdown stripping with a comprehensive `prepareForSpeech` function in `AudioPlayer.tsx`. This handles emojis, headers as section transitions, DeFi-specific abbreviations (e.g., 'APY' to 'A.P.Y.'), and natural currency/percentage reading.
3. **Voice Selection**: Added logic to automatically pick the best available English voice from a priority list of natural/neural voices.
4. **Keepalive Fix**: Implemented a pause/resume heartbeat every 10 seconds to prevent the Web Speech API from cutting off on iOS and Chrome.
5. **Section Tracking**: The player now detects and displays the current section title being read, providing better context to the user.

Verified with `npm run build` and code review.

---
*PR created automatically by Jules for task [13716203120636846195](https://jules.google.com/task/13716203120636846195) started by @3rdeyeadvisors*