### PR TITLE
Full Platform Audit: Notes Fix, Token Sweep, and Branding Updates

### DIFF
--- a/src/components/DefiCalculators.tsx
+++ b/src/components/DefiCalculators.tsx
@@ -110,14 +110,14 @@ const DefiCalculators = () => {
             DeFi Calculators
           </h2>
         </div>
-        <p className="text-muted-foreground font-consciousness max-w-2xl mx-auto">
+        <p className="text-white/50 font-consciousness max-w-2xl mx-auto">
           Essential tools to help you make informed decisions in the DeFi space. 
           Calculate yields, assess risks, and optimize your strategies.
         </p>
       </div>
 
       <Tabs defaultValue="yield" className="w-full">
-        <TabsList className="grid w-full grid-cols-3 bg-muted/50">
+        <TabsList className="grid w-full grid-cols-3 bg-white/5">
           <TabsTrigger value="yield" className="font-consciousness">
             <TrendingUp className="w-4 h-4 mr-2" />
             Yield Calculator
@@ -133,7 +133,7 @@ const DefiCalculators = () => {
         </TabsList>
 
         <TabsContent value="yield">
-          <Card className="p-6 bg-card/60 border-border">
+          <Card className="p-6 bg-card/60 border-white/8">
             <div className="grid md:grid-cols-2 gap-8">
               <div className="space-y-6">
                 <h3 className="text-xl font-consciousness font-semibold text-foreground mb-4">
@@ -193,30 +193,30 @@ const DefiCalculators = () => {
                 {yieldResults ? (
                   <div className="space-y-4">
                     <div className="flex justify-between items-center p-3 bg-primary/10 rounded-lg">
-                      <span className="font-consciousness text-muted-foreground">Final Amount:</span>
+                      <span className="font-consciousness text-white/50">Final Amount:</span>
                       <span className="font-consciousness font-semibold text-primary">
                         ${yieldResults.finalAmount.toLocaleString('en-US', {maximumFractionDigits: 2})}
                       </span>
                     </div>
                     
                     <div className="flex justify-between items-center p-3 bg-accent/10 rounded-lg">
-                      <span className="font-consciousness text-muted-foreground">Total Profit:</span>
+                      <span className="font-consciousness text-white/50">Total Profit:</span>
                       <span className="font-consciousness font-semibold text-accent">
                         ${yieldResults.totalProfit.toLocaleString('en-US', {maximumFractionDigits: 2})}
                       </span>
                     </div>
                     
-                    <div className="flex justify-between items-center p-3 bg-muted/20 rounded-lg">
-                      <span className="font-consciousness text-muted-foreground">Daily Earnings:</span>
+                    <div className="flex justify-between items-center p-3 bg-white/3 rounded-lg">
+                      <span className="font-consciousness text-white/50">Daily Earnings:</span>
                       <span className="font-consciousness font-semibold text-foreground">
                         ${yieldResults.dailyEarnings.toLocaleString('en-US', {maximumFractionDigits: 2})}
                       </span>
                     </div>
                   </div>
                 ) : (
-                  <div className="text-center p-8 bg-muted/10 rounded-lg">
-                    <Percent className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                    <p className="text-muted-foreground font-consciousness">
+                  <div className="text-center p-8 bg-white/3 rounded-lg">
+                    <Percent className="w-12 h-12 text-white/50 mx-auto mb-4" />
+                    <p className="text-white/50 font-consciousness">
                       Enter values to see projected returns
                     </p>
                   </div>
@@ -227,7 +227,7 @@ const DefiCalculators = () => {
         </TabsContent>
 
         <TabsContent value="liquidity">
-          <Card className="p-6 bg-card/60 border-border">
+          <Card className="p-6 bg-card/60 border-white/8">
             <div className="grid md:grid-cols-2 gap-8">
               <div className="space-y-6">
                 <h3 className="text-xl font-consciousness font-semibold text-foreground mb-4">
@@ -291,21 +291,21 @@ const DefiCalculators = () => {
                 {liquidityResults ? (
                   <div className="space-y-4">
                     <div className="flex justify-between items-center p-3 bg-primary/10 rounded-lg">
-                      <span className="font-consciousness text-muted-foreground">Total Pool Value:</span>
+                      <span className="font-consciousness text-white/50">Total Pool Value:</span>
                       <span className="font-consciousness font-semibold text-primary">
                         ${liquidityResults.totalValue.toLocaleString('en-US', {maximumFractionDigits: 2})}
                       </span>
                     </div>
                     
-                    <div className="flex justify-between items-center p-3 bg-muted/20 rounded-lg">
-                      <span className="font-consciousness text-muted-foreground">Token 1 Value:</span>
+                    <div className="flex justify-between items-center p-3 bg-white/3 rounded-lg">
+                      <span className="font-consciousness text-white/50">Token 1 Value:</span>
                       <span className="font-consciousness font-semibold text-foreground">
                         ${liquidityResults.token1Value.toLocaleString('en-US', {maximumFractionDigits: 2})}
                       </span>
                     </div>
                     
-                    <div className="flex justify-between items-center p-3 bg-muted/20 rounded-lg">
-                      <span className="font-consciousness text-muted-foreground">Token 2 Value:</span>
+                    <div className="flex justify-between items-center p-3 bg-white/3 rounded-lg">
+                      <span className="font-consciousness text-white/50">Token 2 Value:</span>
                       <span className="font-consciousness font-semibold text-foreground">
                         ${liquidityResults.token2Value.toLocaleString('en-US', {maximumFractionDigits: 2})}
                       </span>
@@ -313,12 +313,12 @@ const DefiCalculators = () => {
                     
                     <div className="p-3 bg-accent/10 rounded-lg">
                       <div className="flex justify-between items-center mb-2">
-                        <span className="font-consciousness text-muted-foreground">Balance Deviation:</span>
+                        <span className="font-consciousness text-white/50">Balance Deviation:</span>
                         <span className="font-consciousness font-semibold text-accent">
                           {liquidityResults.balance.toFixed(1)}%
                         </span>
                       </div>
-                      <p className="text-sm text-muted-foreground font-consciousness">
+                      <p className="text-sm text-white/50 font-consciousness">
                         {liquidityResults.balance < 5 ? "✅ Well balanced" : 
                          liquidityResults.balance < 15 ? "⚠️ Slightly imbalanced" : 
                          "❌ Significantly imbalanced"}
@@ -326,9 +326,9 @@ const DefiCalculators = () => {
                     </div>
                   </div>
                 ) : (
-                  <div className="text-center p-8 bg-muted/10 rounded-lg">
-                    <DollarSign className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                    <p className="text-muted-foreground font-consciousness">
+                  <div className="text-center p-8 bg-white/3 rounded-lg">
+                    <DollarSign className="w-12 h-12 text-white/50 mx-auto mb-4" />
+                    <p className="text-white/50 font-consciousness">
                       Enter token amounts and prices
                     </p>
                   </div>
@@ -339,7 +339,7 @@ const DefiCalculators = () => {
         </TabsContent>
 
         <TabsContent value="risk">
-          <Card className="p-6 bg-card/60 border-border">
+          <Card className="p-6 bg-card/60 border-white/8">
             <div className="grid md:grid-cols-2 gap-8">
               <div className="space-y-6">
                 <h3 className="text-xl font-consciousness font-semibold text-foreground mb-4">
@@ -363,7 +363,7 @@ const DefiCalculators = () => {
                     <select 
                       value={riskData.riskTolerance}
                       onChange={(e) => setRiskData({...riskData, riskTolerance: e.target.value})}
-                      className="w-full p-2 border border-border rounded-md bg-background font-consciousness text-base min-h-[44px]"
+                      className="w-full p-2 border border-white/8 rounded-md bg-black font-consciousness text-base min-h-[44px]"
                     >
                       <option value="low">Conservative</option>
                       <option value="medium">Moderate</option>
@@ -398,11 +398,11 @@ const DefiCalculators = () => {
                     </div>
                     
                     <div className="space-y-3">
-                      <div className="p-3 bg-muted/10 rounded-lg">
+                      <div className="p-3 bg-white/3 rounded-lg">
                         <h5 className="font-consciousness font-semibold text-foreground mb-2">
                           Recommendations:
                         </h5>
-                        <ul className="text-sm text-muted-foreground font-consciousness space-y-1">
+                        <ul className="text-sm text-white/50 font-consciousness space-y-1">
                           {riskResults.riskLevel === "High" && (
                             <>
                               <li>• Consider reducing position sizes</li>
@@ -432,9 +432,9 @@ const DefiCalculators = () => {
                     </div>
                   </div>
                 ) : (
-                  <div className="text-center p-8 bg-muted/10 rounded-lg">
-                    <AlertTriangle className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                    <p className="text-muted-foreground font-consciousness">
+                  <div className="text-center p-8 bg-white/3 rounded-lg">
+                    <AlertTriangle className="w-12 h-12 text-white/50 mx-auto mb-4" />
+                    <p className="text-white/50 font-consciousness">
                       Complete the assessment for risk analysis
                     </p>
                   </div>
@@ -452,7 +452,7 @@ const DefiCalculators = () => {
             <h4 className="font-consciousness font-semibold text-foreground mb-2">
               Important Disclaimer
             </h4>
-            <p className="text-sm text-muted-foreground font-consciousness leading-relaxed">
+            <p className="text-sm text-white/50 font-consciousness leading-relaxed">
               These calculators are educational tools and do not constitute financial advice. 
               DeFi involves significant risks including smart contract vulnerabilities, impermanent loss, 
               and market volatility. Always do your own research and never invest more than you can afford to lose.

--- a/src/components/admin/RaffleManager.tsx
+++ b/src/components/admin/RaffleManager.tsx
@@ -619,7 +619,7 @@ const RaffleManager = () => {
     <div className="space-y-6 font-body">
       <div>
         <h2 className="text-3xl font-bold mb-2 font-consciousness">Raffle Manager</h2>
-        <p className="text-muted-foreground font-body">
+        <p className="text-white/50 font-body">
           Manage Learn-to-Earn raffles and track participant progress
         </p>
       </div>
@@ -747,7 +747,7 @@ const RaffleManager = () => {
 
               <div className="mt-8 pt-8 border-t">
                 <h3 className="text-lg font-semibold mb-4">Send Announcement Email</h3>
-                <p className="text-sm text-muted-foreground mb-4">
+                <p className="text-sm text-white/50 mb-4">
                   Send the raffle announcement to all newsletter subscribers and registered users.
                 </p>
                 <Button 
@@ -780,7 +780,7 @@ const RaffleManager = () => {
             <CardContent>
               <div className="space-y-4">
                 {raffles.length === 0 ? (
-                  <p className="text-center text-muted-foreground py-8">
+                  <p className="text-center text-white/50 py-8">
                     No raffles created yet
                   </p>
                 ) : (
@@ -789,7 +789,7 @@ const RaffleManager = () => {
                       <div className="flex items-start justify-between">
                         <div>
                           <h3 className="font-semibold">{raffle.title}</h3>
-                          <p className="text-sm text-muted-foreground">
+                          <p className="text-sm text-white/50">
                             ${raffle.prize_amount} {raffle.prize}
                           </p>
                         </div>
@@ -797,7 +797,7 @@ const RaffleManager = () => {
                           {raffle.is_active ? "Active" : "Inactive"}
                         </Badge>
                       </div>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <div className="flex items-center gap-2 text-sm text-white/50">
                         <span>Ends: {new Date(raffle.end_date).toLocaleDateString()}</span>
                       </div>
                       <div className="flex flex-wrap gap-2">
@@ -932,7 +932,7 @@ const RaffleManager = () => {
             </CardHeader>
             <CardContent>
               {verificationTasks.length === 0 ? (
-                <p className="text-center text-muted-foreground py-8">
+                <p className="text-center text-white/50 py-8">
                   No pending verifications. Select "Check Verifications" from the Manage tab.
                 </p>
               ) : (
@@ -942,8 +942,8 @@ const RaffleManager = () => {
                       <div className="flex items-start justify-between">
                         <div>
                           <h3 className="font-semibold">{task.display_name}</h3>
-                          <p className="text-sm text-muted-foreground">{task.email}</p>
-                          <p className="text-xs text-muted-foreground mt-1">
+                          <p className="text-sm text-white/50">{task.email}</p>
+                          <p className="text-xs text-white/50 mt-1">
                             Submitted: {new Date(task.created_at).toLocaleDateString()}
                           </p>
                         </div>
@@ -1045,7 +1045,7 @@ const RaffleManager = () => {
             </CardHeader>
             <CardContent>
               {verifiedTasksHistory.length === 0 ? (
-                <p className="text-center text-muted-foreground py-8">
+                <p className="text-center text-white/50 py-8">
                   No verification history yet. Click "Load History" to view verified/rejected tasks.
                 </p>
               ) : (
@@ -1055,8 +1055,8 @@ const RaffleManager = () => {
                       <div className="flex items-start justify-between">
                         <div>
                           <h3 className="font-semibold">{task.display_name}</h3>
-                          <p className="text-sm text-muted-foreground">{task.email}</p>
-                          <div className="flex items-center gap-4 text-xs text-muted-foreground mt-1">
+                          <p className="text-sm text-white/50">{task.email}</p>
+                          <div className="flex items-center gap-4 text-xs text-white/50 mt-1">
                             <span>Submitted: {new Date(task.created_at).toLocaleDateString()}</span>
                             {task.verified_at && (
                               <span className="font-medium">
@@ -1106,7 +1106,7 @@ const RaffleManager = () => {
                   <CardTitle className="font-consciousness">
                     Raffle Participants
                     {participants.length > 0 && (
-                      <span className="text-muted-foreground ml-2">
+                      <span className="text-white/50 ml-2">
                         ({participants.length})
                       </span>
                     )}
@@ -1193,14 +1193,14 @@ const RaffleManager = () => {
                 <div className="flex items-center justify-center py-12">
                   <div className="text-center space-y-3">
                     <Loader2 className="w-8 h-8 animate-spin mx-auto text-primary" />
-                    <p className="text-muted-foreground">Loading participants...</p>
+                    <p className="text-white/50">Loading participants...</p>
                   </div>
                 </div>
               ) : participants.length === 0 ? (
                 <div className="text-center py-12 space-y-3">
-                  <Users className="w-12 h-12 mx-auto text-muted-foreground/50" />
-                  <p className="text-muted-foreground font-medium">No participants yet</p>
-                  <p className="text-sm text-muted-foreground">
+                  <Users className="w-12 h-12 mx-auto text-white/50" />
+                  <p className="text-white/50 font-medium">No participants yet</p>
+                  <p className="text-sm text-white/50">
                     Click "View Participants" from the Manage tab or use the Refresh button
                   </p>
                 </div>
@@ -1233,14 +1233,14 @@ const RaffleManager = () => {
                                   <Badge variant="outline" className="mr-2">
                                     {ticket.ticket_source}
                                   </Badge>
-                                  <span className="text-muted-foreground">
+                                  <span className="text-white/50">
                                     {new Date(ticket.earned_at).toLocaleString()}
                                   </span>
                                 </div>
                               ))}
                             </div>
                           ) : (
-                            <span className="text-xs text-muted-foreground">No ticket history</span>
+                            <span className="text-xs text-white/50">No ticket history</span>
                           )}
                         </TableCell>
                       </TableRow>

--- a/src/components/community/QADiscussions.tsx
+++ b/src/components/community/QADiscussions.tsx
@@ -240,10 +240,10 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
     return (
       <div className="space-y-4">
         <div className="animate-pulse">
-          <div className="h-6 bg-muted rounded w-1/3 mb-4"></div>
+          <div className="h-6 bg-white/5 rounded w-1/3 mb-4"></div>
           <div className="space-y-3">
-            <div className="h-20 bg-muted rounded"></div>
-            <div className="h-20 bg-muted rounded"></div>
+            <div className="h-20 bg-white/5 rounded"></div>
+            <div className="h-20 bg-white/5 rounded"></div>
           </div>
         </div>
       </div>
@@ -301,7 +301,7 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
                     value={newDiscussion.tags}
                     onChange={(e) => setNewDiscussion(prev => ({ ...prev, tags: e.target.value }))}
                   />
-                  <p className="text-xs text-muted-foreground mt-1">Separate tags with commas</p>
+                  <p className="text-xs text-white/50 mt-1">Separate tags with commas</p>
                 </div>
                 
                 <div className="flex gap-2">
@@ -359,13 +359,13 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
                         )}
                       </div>
                       
-                      <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+                      <p className="text-sm text-white/50 mb-3 line-clamp-2">
                         {discussion.description}
                       </p>
                       
                       {discussion.tags.length > 0 && (
                         <div className="flex items-center gap-1 mb-3">
-                          <Tag className="w-3 h-3 text-muted-foreground" />
+                          <Tag className="w-3 h-3 text-white/50" />
                           {discussion.tags.slice(0, 3).map((tag, index) => (
                             <Badge key={index} variant="secondary" className="text-xs">
                               {tag}
@@ -374,7 +374,7 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
                         </div>
                       )}
                       
-                      <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                      <div className="flex items-center gap-4 text-xs text-white/50">
                         <span className="flex items-center gap-1">
                           <Clock className="w-3 h-3" />
                           {formatDate(discussion.created_at)}
@@ -398,8 +398,8 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
           ) : (
             <Card>
               <CardContent className="p-8 text-center">
-                <HelpCircle className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                <p className="text-muted-foreground">
+                <HelpCircle className="w-12 h-12 text-white/50 mx-auto mb-4" />
+                <p className="text-white/50">
                   No discussions yet. Start the conversation by asking a question!
                 </p>
               </CardContent>
@@ -447,7 +447,7 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
                 
                 {selectedDiscussion.tags.length > 0 && (
                   <div className="flex items-center gap-2 mb-4">
-                    <Tag className="w-4 h-4 text-muted-foreground" />
+                    <Tag className="w-4 h-4 text-white/50" />
                     {selectedDiscussion.tags.map((tag, index) => (
                       <Badge key={index} variant="secondary">
                         {tag}
@@ -456,7 +456,7 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
                   </div>
                 )}
                 
-                <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                <div className="flex items-center gap-4 text-sm text-white/50">
                   <span>by {profiles[selectedDiscussion.user_id]?.display_name || 'Anonymous'}</span>
                   <span>{formatDate(selectedDiscussion.created_at)}</span>
                   <span>{selectedDiscussion.views_count} views</span>
@@ -484,7 +484,7 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
                       <span className="font-medium text-sm">
                         {profiles[reply.user_id]?.display_name || 'Anonymous User'}
                       </span>
-                      <span className="text-xs text-muted-foreground">
+                      <span className="text-xs text-white/50">
                         {formatDate(reply.created_at)}
                       </span>
                       {reply.is_solution && (
@@ -502,7 +502,7 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="text-xs text-muted-foreground hover:text-primary"
+                        className="text-xs text-white/50 hover:text-primary"
                       >
                         <Heart className="w-4 h-4 mr-1" />
                         {reply.likes_count}
@@ -547,7 +547,7 @@ export const QADiscussions = ({ contentType, contentId, title }: QADiscussionsPr
           ) : (
             <Card>
               <CardContent className="p-4 text-center">
-                <p className="text-muted-foreground mb-3">Sign in to reply to this discussion</p>
+                <p className="text-white/50 mb-3">Sign in to reply to this discussion</p>
                 <Button variant="outline" onClick={() => navigate('/auth')}>
                   Sign In
                 </Button>

--- a/src/components/course/EnhancedContentPlayer.tsx
+++ b/src/components/course/EnhancedContentPlayer.tsx
@@ -367,7 +367,7 @@ export const EnhancedContentPlayer = ({
       case 'video': return 'bg-destructive/10 text-destructive border-destructive/20';
       case 'text': return 'bg-primary/10 text-primary border-primary/20';
       case 'interactive': return 'bg-awareness/10 text-awareness border-awareness/20';
-      default: return 'bg-muted text-muted-foreground border-border';
+      default: return 'bg-white/8 text-white/60 border-white/15';
     }
   };
 
@@ -423,7 +423,7 @@ export const EnhancedContentPlayer = ({
             <Badge className={`${getTypeColor(module.type)} text-xs md:text-sm`}>
               {getTypeIcon(module.type)} {module.type.charAt(0).toUpperCase() + module.type.slice(1)}
             </Badge>
-            <div className="flex items-center gap-1 md:gap-2 text-muted-foreground">
+            <div className="flex items-center gap-1 md:gap-2 text-white/50">
               <Clock className="w-3 h-3 md:w-4 md:h-4" />
               <span className="text-xs md:text-sm">{module.duration} min</span>
             </div>
@@ -455,7 +455,7 @@ export const EnhancedContentPlayer = ({
               variant="ghost"
               size="sm"
               onClick={toggleBookmark}
-              className="text-muted-foreground hover:text-foreground p-1 sm:p-1.5 md:p-2 min-h-[36px] sm:min-h-[40px]"
+              className="text-white/50 hover:text-white p-1 sm:p-1.5 md:p-2 min-h-[36px] sm:min-h-[40px]"
             >
               {isBookmarked ? (
                 <BookmarkCheck className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
@@ -463,13 +463,13 @@ export const EnhancedContentPlayer = ({
                 <Bookmark className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
               )}
             </Button>
-            <span className="text-xs md:text-sm text-muted-foreground">
+            <span className="text-xs md:text-sm text-white/50">
               {currentModuleIndex + 1} of {totalModules}
             </span>
           </div>
         </div>
 
-        <h1 className="text-lg sm:text-xl md:text-3xl font-consciousness font-bold text-foreground mb-2.5 sm:mb-3 md:mb-4 text-center break-words leading-tight px-2 sm:px-0">
+        <h1 className="text-lg sm:text-xl md:text-3xl font-consciousness font-bold text-white mb-2.5 sm:mb-3 md:mb-4 text-center break-words leading-tight px-2 sm:px-0">
           {module.title}
         </h1>
 
@@ -478,8 +478,8 @@ export const EnhancedContentPlayer = ({
           {module.type === 'text' && (
             <div>
               <div className="flex items-center justify-between mb-1.5 sm:mb-2">
-                <span className="text-xs sm:text-sm text-muted-foreground">Reading Progress</span>
-                <span className="text-xs sm:text-sm text-muted-foreground">{Math.round(readingProgress)}%</span>
+                <span className="text-xs sm:text-sm text-white/50">Reading Progress</span>
+                <span className="text-xs sm:text-sm text-white/50">{Math.round(readingProgress)}%</span>
               </div>
               <Progress value={readingProgress} className="h-1.5 sm:h-2" />
             </div>
@@ -487,8 +487,8 @@ export const EnhancedContentPlayer = ({
           
           <div>
             <div className="flex items-center justify-between mb-1.5 sm:mb-2">
-              <span className="text-xs sm:text-sm text-muted-foreground">Time Spent</span>
-              <span className="text-xs sm:text-sm text-muted-foreground">{timeSpent} min</span>
+              <span className="text-xs sm:text-sm text-white/50">Time Spent</span>
+              <span className="text-xs sm:text-sm text-white/50">{timeSpent} min</span>
             </div>
             <Progress value={Math.min((timeSpent / module.duration) * 100, 100)} className="h-1.5 sm:h-2" />
           </div>
@@ -557,7 +557,7 @@ export const EnhancedContentPlayer = ({
 
               {module.type === 'video' && module.content.videoUrl && (
                 <div className="space-y-4">
-                  <div className="aspect-video bg-black rounded-xl overflow-hidden shadow-2xl border border-border">
+                  <div className="aspect-video bg-black rounded-xl overflow-hidden shadow-2xl border border-white/8">
                     <iframe
                       src={module.content.videoUrl}
                       className="w-full h-full"
@@ -567,13 +567,13 @@ export const EnhancedContentPlayer = ({
                   </div>
                   
                   {/* Video Progress Tracker (Simulated) */}
-                  <div className="space-y-2 bg-muted/30 p-4 rounded-lg">
+                  <div className="space-y-2 bg-white/5 p-4 rounded-lg">
                     <div className="flex items-center justify-between mb-1">
-                      <span className="text-xs font-medium text-muted-foreground">Video Progress</span>
-                      <span className="text-xs font-medium text-muted-foreground">45% Complete</span>
+                      <span className="text-xs font-medium text-white/50">Video Progress</span>
+                      <span className="text-xs font-medium text-white/50">45% Complete</span>
                     </div>
                     <Progress value={45} className="h-2" />
-                    <div className="flex justify-between text-[10px] text-muted-foreground">
+                    <div className="flex justify-between text-[10px] text-white/50">
                       <span>05:23</span>
                       <span>12:45</span>
                     </div>
@@ -651,14 +651,14 @@ export const EnhancedContentPlayer = ({
             {module.resources && module.resources.length > 0 ? (
               <div className="space-y-3">
                 {module.resources.map((resource, index) => (
-                  <div key={index} className="flex items-center justify-between p-4 bg-muted rounded-lg hover:bg-muted/80 transition-colors">
+                  <div key={index} className="flex items-center justify-between p-4 bg-white/5 rounded-lg hover:bg-white/8 transition-colors">
                     <div className="flex items-center gap-3">
                       {resource.type === 'pdf' && <FileText className="w-5 h-5 text-red-600" />}
                       {resource.type === 'link' && <ExternalLink className="w-5 h-5 text-blue-600" />}
                       {resource.type === 'download' && <Download className="w-5 h-5 text-green-600" />}
                       <div>
                         <span className="font-medium">{resource.title}</span>
-                        <p className="text-sm text-muted-foreground capitalize">{resource.type}</p>
+                        <p className="text-sm text-white/50 capitalize">{resource.type}</p>
                       </div>
                     </div>
                     <Button 
@@ -672,7 +672,7 @@ export const EnhancedContentPlayer = ({
                 ))}
               </div>
             ) : (
-              <p className="text-center text-muted-foreground py-8">
+              <p className="text-center text-white/50 py-8">
                 No additional resources available for this module.
               </p>
             )}

--- a/src/components/course/FullscreenContentViewer.tsx
+++ b/src/components/course/FullscreenContentViewer.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Textarea } from '@/components/ui/textarea';
+
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { useFullscreen } from '@/hooks/useFullscreen';
@@ -215,7 +215,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
-      className="fixed inset-0 z-[9999] bg-background overflow-hidden"
+      className="fixed inset-0 z-[9999] bg-[#080808] overflow-hidden"
       onClick={toggleUI}
       onTouchStart={handleTouchStart}
       onTouchMove={swipeHandlers.onTouchMove}
@@ -235,7 +235,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
                 variant="ghost"
                 size="icon"
                 onClick={handleClose}
-                className="bg-background/20 backdrop-blur-md rounded-full w-10 h-10 border border-white/10"
+                className="bg-white/5 backdrop-blur-md rounded-full w-10 h-10 border border-white/10"
                 aria-label="Exit focus mode"
               >
                 <X className="w-5 h-5" />
@@ -254,7 +254,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
           transition={{ duration: 0.3, ease: "easeInOut" }}
           className="absolute top-0 left-0 right-0 z-50 flex flex-col"
         >
-          <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-background/95 backdrop-blur-sm safe-area-inset-top">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-white/10 bg-[#080808]/95 backdrop-blur-sm safe-area-inset-top">
             <div className="flex items-center gap-3 flex-1 min-w-0">
               <Button
                 variant="ghost"
@@ -267,7 +267,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
               </Button>
               <div className="min-w-0">
                 {courseTitle && (
-                  <p className="text-xs text-muted-foreground truncate">{courseTitle}</p>
+                  <p className="text-xs text-white/50 truncate">{courseTitle}</p>
                 )}
                 <h1 className="text-sm font-semibold text-foreground truncate">
                   {title}
@@ -276,7 +276,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
             </div>
 
             <div className="flex items-center gap-2 shrink-0">
-              <span className="text-sm text-muted-foreground whitespace-nowrap mr-2">
+              <span className="text-sm text-white/50 whitespace-nowrap mr-2">
                 {currentIndex + 1} / {totalModules}
               </span>
 
@@ -313,7 +313,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
           </div>
 
           {/* Progress dots */}
-          <div className="flex justify-center gap-1.5 py-2 bg-background/80 border-b border-border/10">
+          <div className="flex justify-center gap-1.5 py-2 bg-[#080808]/80 border-b border-white/5">
             {Array.from({ length: totalModules }).map((_, i) => (
               <div
                 key={i}
@@ -323,7 +323,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
                     ? "bg-primary"
                     : i < currentIndex
                     ? "bg-primary/40"
-                    : "bg-muted"
+                    : "bg-white/5"
                 )}
               />
             ))}
@@ -346,7 +346,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
               showSidebar ? "max-w-4xl" : "max-w-6xl"
             )}>
               {type === 'video' && videoUrl && (
-                <div className="aspect-video bg-black rounded-xl overflow-hidden mb-8 shadow-2xl border border-border">
+                <div className="aspect-video bg-black rounded-xl overflow-hidden mb-8 shadow-2xl border border-white/10">
                   <iframe
                     src={videoUrl}
                     className="w-full h-full"
@@ -366,9 +366,9 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
                 animate={{ x: 0, opacity: 1 }}
                 exit={{ x: 350, opacity: 0 }}
                 transition={{ type: "spring", damping: 25, stiffness: 200 }}
-                className="hidden lg:flex w-[350px] border-l border-border bg-background/50 backdrop-blur-md flex-col overflow-hidden pt-16"
+                className="hidden lg:flex w-[350px] border-l border-white/10 bg-[#080808]/50 backdrop-blur-md flex-col overflow-hidden pt-16"
               >
-                <div className="p-4 border-b border-border flex items-center justify-between">
+                <div className="p-4 border-b border-white/10 flex items-center justify-between">
                   <h2 className="font-consciousness font-semibold flex items-center gap-2">
                     <Save className="w-4 h-4 text-primary" />
                     Study Tools
@@ -398,10 +398,28 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
                   </div>
 
                   <TabsContent value="notes" className="flex-1 overflow-hidden flex flex-col p-4 mt-0">
-                    <NotesEditor
-                      initialValue={notes}
-                      onSave={onNotesChange || (() => {})}
-                      onClear={() => onNotesChange?.('')}
+                    <textarea
+                      style={{
+                        width: '100%',
+                        flex: 1,
+                        minHeight: '180px',
+                        background: 'rgba(255,255,255,0.05)',
+                        border: '1px solid rgba(255,255,255,0.12)',
+                        borderRadius: '12px',
+                        padding: '12px 16px',
+                        color: 'rgba(255,255,255,0.85)',
+                        fontSize: '14px',
+                        lineHeight: '1.6',
+                        fontFamily: 'Inter, sans-serif',
+                        resize: 'none',
+                        outline: 'none',
+                        boxSizing: 'border-box',
+                      }}
+                      onFocus={e => e.target.style.borderColor = 'rgba(139,92,246,0.5)'}
+                      onBlur={e => e.target.style.borderColor = 'rgba(255,255,255,0.12)'}
+                      value={notes}
+                      onChange={(e) => onNotesChange?.(e.target.value)}
+                      placeholder="Take notes while you learn..."
                     />
                   </TabsContent>
 
@@ -413,11 +431,11 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
                           {resources.map((resource, index) => (
                             <div
                               key={index}
-                              className="group p-3 rounded-lg border border-border bg-muted/20 hover:bg-muted/40 transition-all cursor-pointer"
+                              className="group p-3 rounded-lg border border-white/10 bg-white/3 hover:bg-white/8 transition-all cursor-pointer"
                               onClick={() => window.open(resource.url, '_blank')}
                             >
                               <div className="flex items-start gap-3">
-                                <div className="p-2 rounded-md bg-background border border-border text-primary group-hover:scale-110 transition-transform">
+                                <div className="p-2 rounded-md bg-[#080808] border border-white/10 text-primary group-hover:scale-110 transition-transform">
                                   {resource.type === 'pdf' && <FileText className="w-4 h-4" />}
                                   {resource.type === 'link' && <ExternalLink className="w-4 h-4" />}
                                   {resource.type === 'download' && <Download className="w-4 h-4" />}
@@ -426,7 +444,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
                                   <p className="text-xs font-medium leading-tight group-hover:text-primary transition-colors line-clamp-2">
                                     {resource.title}
                                   </p>
-                                  <p className="text-[10px] text-muted-foreground mt-1 capitalize">
+                                  <p className="text-[10px] text-white/50 mt-1 capitalize">
                                     {resource.type}
                                   </p>
                                 </div>
@@ -436,16 +454,16 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
                         </div>
                       ) : (
                         <div className="text-center py-12 px-4 border-2 border-dashed border-muted rounded-xl">
-                          <FileText className="w-8 h-8 text-muted-foreground/30 mx-auto mb-2" />
-                          <p className="text-xs text-muted-foreground">No resources for this module</p>
+                          <FileText className="w-8 h-8 text-white/30 mx-auto mb-2" />
+                          <p className="text-xs text-white/50">No resources for this module</p>
                         </div>
                       )}
                     </ScrollArea>
                   </TabsContent>
                 </Tabs>
 
-                <div className="p-4 border-t border-border bg-muted/10">
-                  <p className="text-[10px] text-center text-muted-foreground">
+                <div className="p-4 border-t border-white/10 bg-white/3">
+                  <p className="text-[10px] text-center text-white/50">
                     Notes are synced across your devices automatically
                   </p>
                 </div>
@@ -462,7 +480,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
             opacity: showUI ? 1 : 0
           }}
           transition={{ duration: 0.3, ease: "easeInOut" }}
-          className="absolute bottom-0 left-0 right-0 border-t border-border bg-background/95 backdrop-blur-sm px-4 py-3 safe-area-inset-bottom z-50"
+          className="absolute bottom-0 left-0 right-0 border-t border-white/10 bg-[#080808]/95 backdrop-blur-sm px-4 py-3 safe-area-inset-bottom z-50"
         >
           <div className="flex items-center justify-between max-w-4xl mx-auto">
             <Button
@@ -476,7 +494,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
             </Button>
 
             <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2 text-sm text-white/50">
                 <span className="hidden sm:inline">Swipe or use arrows to navigate</span>
                 <span className="sm:hidden">← Swipe →</span>
               </div>
@@ -519,7 +537,7 @@ export const FullscreenContentViewer: React.FC<FullscreenContentViewerProps> = (
           className="absolute inset-0 pointer-events-none flex items-center justify-center"
           aria-hidden="true"
         >
-          <div className="flex items-center gap-4 text-muted-foreground/50 text-lg">
+          <div className="flex items-center gap-4 text-white/50 text-lg">
             <ChevronLeft className="w-8 h-8 animate-pulse" />
             <span>Swipe to navigate</span>
             <ChevronRight className="w-8 h-8 animate-pulse" />

--- a/src/components/course/NotesEditor.tsx
+++ b/src/components/course/NotesEditor.tsx
@@ -1,6 +1,4 @@
 import { useState, useRef, useEffect } from 'react';
-import { Textarea } from '@/components/ui/textarea';
-import { Button } from '@/components/ui/button';
 import { MessageSquare, Save, Trash2 } from 'lucide-react';
 
 interface NotesEditorProps {
@@ -13,22 +11,33 @@ const NotesEditor = ({ initialValue, onSave, onClear }: NotesEditorProps) => {
   const [value, setValue] = useState(initialValue);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isDirty, setIsDirty] = useState(false);
+  const hasInitialized = useRef(false);
 
-  // Sync if initialValue changes (e.g. module change)
+  // Only sync initialValue on first mount or when module changes (not on every parent re-render)
   useEffect(() => {
-    setValue(initialValue);
-    setIsDirty(false);
-  }, [initialValue]);
+    if (!hasInitialized.current) {
+      setValue(initialValue);
+      hasInitialized.current = true;
+    }
+  }, []);
+
+  // Reset when the module actually changes (initialValue will be different)
+  const prevInitialRef = useRef(initialValue);
+  useEffect(() => {
+    if (prevInitialRef.current !== initialValue && !isDirty) {
+      setValue(initialValue);
+      prevInitialRef.current = initialValue;
+    }
+  }, [initialValue, isDirty]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const val = e.target.value;
     setValue(val);
     setIsDirty(true);
-    // Auto-save to localStorage via debounce
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       onSave(val);
-    }, 800);
+    }, 1500); // longer debounce to avoid parent re-render loop
   };
 
   const handleSave = () => {
@@ -49,31 +58,53 @@ const NotesEditor = ({ initialValue, onSave, onClear }: NotesEditorProps) => {
         <MessageSquare className="w-4 h-4 text-violet-400" />
         <h3 className="font-consciousness text-base font-bold text-white">Personal Notes</h3>
         {isDirty && (
-          <span className="font-body text-[10px] uppercase tracking-widest text-white/30 ml-auto">Unsaved changes</span>
+          <span className="font-body text-[10px] uppercase tracking-widest text-white/30 ml-auto">Unsaved</span>
         )}
       </div>
-      <Textarea
+      <textarea
         placeholder="Add your notes about this module... These are private to you."
         value={value}
         onChange={handleChange}
-        className="min-h-[240px] font-body text-sm text-white/80 bg-white/3 border border-white/10 focus:border-violet-500/50 resize-none leading-relaxed placeholder:text-white/20 rounded-xl"
+        style={{
+          width: '100%',
+          minHeight: '240px',
+          background: 'rgba(255,255,255,0.05)',
+          border: '1px solid rgba(255,255,255,0.12)',
+          borderRadius: '12px',
+          padding: '12px 16px',
+          color: 'rgba(255,255,255,0.85)',
+          fontSize: '14px',
+          lineHeight: '1.6',
+          fontFamily: 'Inter, sans-serif',
+          resize: 'vertical',
+          outline: 'none',
+          boxSizing: 'border-box',
+        }}
+        onFocus={e => e.target.style.borderColor = 'rgba(139,92,246,0.5)'}
+        onBlur={e => {
+          e.target.style.borderColor = 'rgba(255,255,255,0.12)';
+          if (isDirty) {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+            onSave(value);
+            setIsDirty(false);
+          }
+        }}
       />
       <div className="flex gap-2">
-        <Button
+        <button
           onClick={handleSave}
-          className="font-body bg-violet-600 hover:bg-violet-500 text-white rounded-xl px-4 py-2 text-sm flex items-center gap-2"
+          className="font-body bg-violet-600 hover:bg-violet-500 text-white rounded-xl px-4 py-2 text-sm flex items-center gap-2 transition-colors"
         >
           <Save className="w-3.5 h-3.5" />
           Save Notes
-        </Button>
-        <Button
+        </button>
+        <button
           onClick={handleClear}
-          variant="outline"
-          className="font-body border-white/10 text-white/50 hover:text-white hover:border-white/20 rounded-xl px-4 py-2 text-sm flex items-center gap-2 bg-transparent"
+          className="font-body border border-white/10 text-white/50 hover:text-white hover:border-white/20 rounded-xl px-4 py-2 text-sm flex items-center gap-2 transition-colors bg-transparent"
         >
           <Trash2 className="w-3.5 h-3.5" />
           Clear
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/src/components/dashboard/EnhancedDashboard.tsx
+++ b/src/components/dashboard/EnhancedDashboard.tsx
@@ -499,7 +499,7 @@ export const EnhancedDashboard = () => {
     switch (category) {
       case "free": return "bg-awareness/20 text-awareness border-awareness/30";
       case "paid": return "bg-primary/20 text-primary border-primary/30";
-      default: return "bg-muted/20 text-muted-foreground border-border";
+      default: return "bg-white/3 text-white/50 border-white/8";
     }
   };
 
@@ -508,7 +508,7 @@ export const EnhancedDashboard = () => {
       case "Beginner": return "text-awareness";
       case "Intermediate": return "text-accent";
       case "Advanced": return "text-destructive";
-      default: return "text-muted-foreground";
+      default: return "text-white/50";
     }
   };
 
@@ -711,7 +711,7 @@ export const EnhancedDashboard = () => {
               );
             })}
           </div>
-          <div className="mt-4 flex items-center gap-4 text-xs text-muted-foreground justify-center sm:justify-start">
+          <div className="mt-4 flex items-center gap-4 text-xs text-white/50 justify-center sm:justify-start">
             <div className="flex items-center gap-1">
               <div className="w-2 h-2 rounded-full bg-primary" />
               <span>Goal: 60m / day</span>
@@ -816,7 +816,7 @@ export const EnhancedDashboard = () => {
                       <h3 className="font-consciousness font-semibold text-foreground mb-3 line-clamp-2">
                         {course.title}
                       </h3>
-                      <div className="flex items-center gap-4 mb-4 text-sm text-muted-foreground">
+                      <div className="flex items-center gap-4 mb-4 text-sm text-white/50">
                         <span className="flex items-center gap-1">
                           <Clock className="w-4 h-4" />
                           {course.duration}
@@ -848,7 +848,7 @@ export const EnhancedDashboard = () => {
                   {notStarted.map(course => (
                     <Card
                       key={course.id}
-                      className="p-6 bg-card/60 border-border hover:border-primary/40 transition-all cursor-pointer group"
+                      className="p-6 bg-card/60 border-white/8 hover:border-primary/40 transition-all cursor-pointer group"
                       onClick={() => navigate(`/courses/${course.id}`)}
                     >
                       <div className="flex items-start justify-between mb-4">
@@ -863,7 +863,7 @@ export const EnhancedDashboard = () => {
                       <h3 className="font-consciousness font-semibold text-foreground mb-3 line-clamp-2">
                         {course.title}
                       </h3>
-                      <div className="flex items-center gap-4 mb-4 text-sm text-muted-foreground">
+                      <div className="flex items-center gap-4 mb-4 text-sm text-white/50">
                         <span className="flex items-center gap-1">
                           <Clock className="w-4 h-4" />
                           {course.duration}
@@ -894,15 +894,15 @@ export const EnhancedDashboard = () => {
                   className={`p-6 transition-all ${
                     achievement.earned 
                       ? "bg-gradient-to-br from-primary/10 to-primary/5 border-primary/30 shadow-lg" 
-                      : "bg-card/60 border-border opacity-60"
+                      : "bg-card/60 border-white/8 opacity-60"
                   }`}
                 >
                   <div className="flex items-center gap-3 mb-3">
                     <div className={`p-2 rounded-full ${
-                      achievement.earned ? "bg-primary/20" : "bg-muted"
+                      achievement.earned ? "bg-primary/20" : "bg-white/5"
                     }`}>
                       <achievement.icon className={`w-6 h-6 ${
-                        achievement.earned ? "text-primary" : "text-muted-foreground"
+                        achievement.earned ? "text-primary" : "text-white/50"
                       }`} />
                     </div>
                     <div>
@@ -910,13 +910,13 @@ export const EnhancedDashboard = () => {
                         {achievement.title}
                       </h3>
                       {achievement.earned && achievement.date && (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-xs text-white/50">
                           Earned {achievement.date}
                         </p>
                       )}
                     </div>
                   </div>
-                  <p className="text-sm text-muted-foreground font-consciousness">
+                  <p className="text-sm text-white/50 font-consciousness">
                     {achievement.description}
                   </p>
                 </Card>
@@ -925,7 +925,7 @@ export const EnhancedDashboard = () => {
           </TabsContent>
 
           <TabsContent value="activity" className="space-y-6">
-            <Card className="p-6 bg-card/60 border-border">
+            <Card className="p-6 bg-card/60 border-white/8">
               <div className="flex items-center gap-3 mb-4">
                 <Calendar className="w-6 h-6 text-primary" />
                 <h3 className="font-consciousness font-semibold text-foreground">
@@ -937,7 +937,7 @@ export const EnhancedDashboard = () => {
                   recentActivity.map((activity) => {
                     const isQuiz = activity.type === 'quiz';
                     return (
-                      <div key={activity.id} className="flex items-center gap-3 p-3 bg-muted/20 rounded-lg">
+                      <div key={activity.id} className="flex items-center gap-3 p-3 bg-white/3 rounded-lg">
                         <div className={`p-2 rounded-full ${
                           isQuiz
                             ? (activity.passed ? "bg-awareness/20 text-awareness" : "bg-destructive/20 text-destructive")
@@ -959,7 +959,7 @@ export const EnhancedDashboard = () => {
                               activity.action_type === 'tutorial_completed' ? 'Finished a tutorial' : 'Earned points'
                             )}
                           </p>
-                          <p className="text-xs text-muted-foreground">
+                          <p className="text-xs text-white/50">
                             {new Date(activity.created_at).toLocaleDateString()} • {new Date(activity.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                           </p>
                         </div>
@@ -976,7 +976,7 @@ export const EnhancedDashboard = () => {
                     );
                   })
                 ) : (
-                  <p className="text-center text-muted-foreground font-consciousness py-8">
+                  <p className="text-center text-white/50 font-consciousness py-8">
                     No recent activity. Start learning to see your progress here!
                   </p>
                 )}
@@ -1059,7 +1059,7 @@ export const EnhancedDashboard = () => {
                   >
                     <div className="flex items-center justify-between mb-2">
                       <h4 className="font-semibold text-foreground line-clamp-1">{course.title}</h4>
-                      <ExternalLink className="w-4 h-4 text-muted-foreground group-hover:text-primary" />
+                      <ExternalLink className="w-4 h-4 text-white/50 group-hover:text-primary" />
                     </div>
                     <div className="flex items-center gap-2 mb-3">
                       <Badge className={getCategoryColor(course.category)} variant="outline">
@@ -1076,7 +1076,7 @@ export const EnhancedDashboard = () => {
                   </Card>
                 ))
               ) : (
-                <p className="text-center text-muted-foreground py-8">
+                <p className="text-center text-white/50 py-8">
                   No courses enrolled yet. Start learning!
                 </p>
               )}
@@ -1109,7 +1109,7 @@ export const EnhancedDashboard = () => {
                       <h4 className="font-semibold text-foreground line-clamp-1">{course.title}</h4>
                       <div className="flex items-center gap-2">
                         <CheckCircle2 className="w-4 h-4 text-awareness" />
-                        <ExternalLink className="w-4 h-4 text-muted-foreground group-hover:text-awareness" />
+                        <ExternalLink className="w-4 h-4 text-white/50 group-hover:text-awareness" />
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
@@ -1123,7 +1123,7 @@ export const EnhancedDashboard = () => {
                   </Card>
                 ))
               ) : (
-                <p className="text-center text-muted-foreground py-8">
+                <p className="text-center text-white/50 py-8">
                   No courses completed yet. Keep learning!
                 </p>
               )}
@@ -1160,7 +1160,7 @@ export const EnhancedDashboard = () => {
                       </h4>
                       <Badge className="bg-awareness/20 text-awareness">{quiz.score}%</Badge>
                     </div>
-                    <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <div className="flex items-center justify-between text-sm text-white/50">
                       <span>Passed on {new Date(quiz.created_at).toLocaleDateString()}</span>
                       {quiz.time_taken && (
                         <span className="flex items-center gap-1">
@@ -1172,7 +1172,7 @@ export const EnhancedDashboard = () => {
                   </Card>
                 ))
               ) : (
-                <p className="text-center text-muted-foreground py-8">
+                <p className="text-center text-white/50 py-8">
                   No quizzes passed yet. Take a quiz to get started!
                 </p>
               )}
@@ -1217,7 +1217,7 @@ export const EnhancedDashboard = () => {
                         {quiz.score}%
                       </Badge>
                     </div>
-                    <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <div className="flex items-center justify-between text-sm text-white/50">
                       <span className="flex items-center gap-1">
                         {quiz.passed ? (
                           <CheckCircle2 className="w-3 h-3 text-awareness" />
@@ -1231,7 +1231,7 @@ export const EnhancedDashboard = () => {
                   </Card>
                 ))
               ) : (
-                <p className="text-center text-muted-foreground py-8">
+                <p className="text-center text-white/50 py-8">
                   No quiz attempts yet. Take a quiz to get started!
                 </p>
               )}
@@ -1251,26 +1251,26 @@ export const EnhancedDashboard = () => {
             </SheetHeader>
             <div className="space-y-4 mt-6">
               {/* Summary Stats */}
-              <Card className="p-4 bg-muted/30">
+              <Card className="p-4 bg-white/5">
                 <div className="grid grid-cols-3 gap-4 text-center">
                   <div>
                     <p className="text-2xl font-bold text-primary">{enrolledCourses}</p>
-                    <p className="text-xs text-muted-foreground">Enrolled</p>
+                    <p className="text-xs text-white/50">Enrolled</p>
                   </div>
                   <div>
                     <p className="text-2xl font-bold text-awareness">{completedCourses}</p>
-                    <p className="text-xs text-muted-foreground">Completed</p>
+                    <p className="text-xs text-white/50">Completed</p>
                   </div>
                   <div>
                     <p className="text-2xl font-bold text-accent">{analyticsStats.modulesCompleted}</p>
-                    <p className="text-xs text-muted-foreground">Modules</p>
+                    <p className="text-xs text-white/50">Modules</p>
                   </div>
                 </div>
               </Card>
 
               {/* Per-course breakdown */}
               <div className="space-y-3">
-                <h4 className="font-semibold text-sm text-muted-foreground">Course Breakdown</h4>
+                <h4 className="font-semibold text-sm text-white/50">Course Breakdown</h4>
                 {courses.map(course => {
                   const progress = courseProgress[course.id]?.completion_percentage || 0;
                   const isCompleted = progress === 100;
@@ -1284,7 +1284,7 @@ export const EnhancedDashboard = () => {
                           ? 'bg-awareness/5 hover:border-awareness/40' 
                           : isStarted 
                           ? 'hover:border-primary/40' 
-                          : 'hover:border-border'
+                          : 'hover:border-white/8'
                       }`}
                       onClick={() => {
                         setOpenDetail(null);

--- a/src/components/orion/OrionChat.tsx
+++ b/src/components/orion/OrionChat.tsx
@@ -75,13 +75,13 @@ const OrionChat = () => {
             transition={{ type: "spring", damping: 20, stiffness: 300 }}
             className="absolute bottom-16 right-0 w-64 md:w-72"
           >
-            <div className="relative bg-card border border-border rounded-2xl rounded-br-sm p-4 shadow-xl">
+            <div className="relative bg-card border border-white/8 rounded-2xl rounded-br-sm p-4 shadow-xl">
               <button
                 onClick={dismissGreeting}
-                className="absolute top-2 right-2 p-1 rounded-full hover:bg-muted transition-colors"
+                className="absolute top-2 right-2 p-1 rounded-full hover:bg-white/5 transition-colors"
                 aria-label="Dismiss greeting"
               >
-                <X className="w-4 h-4 text-muted-foreground" />
+                <X className="w-4 h-4 text-white/50" />
               </button>
               <p className="text-sm text-foreground pr-6">{greeting}</p>
               <Button
@@ -94,7 +94,7 @@ const OrionChat = () => {
               </Button>
             </div>
             {/* Bubble pointer */}
-            <div className="absolute -bottom-2 right-6 w-4 h-4 bg-card border-r border-b border-border transform rotate-45" />
+            <div className="absolute -bottom-2 right-6 w-4 h-4 bg-card border-r border-b border-white/8 transform rotate-45" />
           </motion.div>
         )}
       </AnimatePresence>
@@ -107,23 +107,23 @@ const OrionChat = () => {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.9, y: 20 }}
             transition={{ type: "spring", damping: 25, stiffness: 300 }}
-            className="absolute bottom-16 right-0 w-[calc(100vw-2rem)] max-w-sm md:w-96 bg-card border border-border rounded-2xl shadow-2xl overflow-hidden"
+            className="absolute bottom-16 right-0 w-[calc(100vw-2rem)] max-w-sm md:w-96 bg-card border border-white/8 rounded-2xl shadow-2xl overflow-hidden"
           >
             {/* Header */}
-            <div className="flex items-center justify-between p-4 border-b border-border bg-muted/50">
+            <div className="flex items-center justify-between p-4 border-b border-white/8 bg-white/5">
               <div className="flex items-center gap-3">
                 <OrionAvatar size="sm" isThinking={isLoading} />
                 <div>
                   <h3 className="font-semibold text-foreground">Orion</h3>
-                  <p className="text-xs text-muted-foreground">3EA Assistant</p>
+                  <p className="text-xs text-white/50">3EA Assistant</p>
                 </div>
               </div>
               <button
                 onClick={closeChat}
-                className="p-2 rounded-full hover:bg-muted transition-colors"
+                className="p-2 rounded-full hover:bg-white/5 transition-colors"
                 aria-label="Close chat"
               >
-                <X className="w-5 h-5 text-muted-foreground" />
+                <X className="w-5 h-5 text-white/50" />
               </button>
             </div>
 
@@ -142,7 +142,7 @@ const OrionChat = () => {
                       className={`max-w-[85%] rounded-2xl px-4 py-2 ${
                         msg.role === "user"
                           ? "bg-primary text-primary-foreground rounded-br-sm"
-                          : "bg-muted text-foreground rounded-bl-sm"
+                          : "bg-white/5 text-foreground rounded-bl-sm"
                       }`}
                     >
                       <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
@@ -156,7 +156,7 @@ const OrionChat = () => {
                     animate={{ opacity: 1 }}
                     className="flex justify-start"
                   >
-                    <div className="bg-muted rounded-2xl rounded-bl-sm px-4 py-3">
+                    <div className="bg-white/5 rounded-2xl rounded-bl-sm px-4 py-3">
                       <div className="flex gap-1">
                         <motion.div
                           className="w-2 h-2 bg-primary/60 rounded-full"
@@ -181,7 +181,7 @@ const OrionChat = () => {
                 {/* Quick Actions - show only if few messages */}
                 {messages.length <= 1 && (
                   <div className="pt-2">
-                    <p className="text-xs text-muted-foreground mb-2">Quick questions:</p>
+                    <p className="text-xs text-white/50 mb-2">Quick questions:</p>
                     <div className="flex flex-wrap gap-2">
                       {quickActions.map((action) => (
                         <button
@@ -199,7 +199,7 @@ const OrionChat = () => {
             </ScrollArea>
 
             {/* Input */}
-            <div className="p-4 border-t border-border bg-muted/30">
+            <div className="p-4 border-t border-white/8 bg-white/5">
               <div className="flex gap-2">
                 <Input
                   ref={inputRef}

--- a/src/components/quiz/QuizComponent.tsx
+++ b/src/components/quiz/QuizComponent.tsx
@@ -481,7 +481,7 @@ export const QuizComponent = ({ courseId, moduleId, quiz, onComplete }: QuizComp
             <h3 className="font-semibold mb-3">Previous Attempts</h3>
             <div className="space-y-2">
               {attempts.slice(0, 3).map((attempt, index) => (
-                <div key={attempt.id} className="flex items-center justify-between p-3 bg-muted rounded-lg">
+                <div key={attempt.id} className="flex items-center justify-between p-3 bg-white/5 rounded-lg">
                   <span>Attempt {attempts.length - index}</span>
                   <div className="flex items-center gap-2">
                     <Badge variant={attempt.passed ? "default" : "destructive"}>
@@ -499,7 +499,7 @@ export const QuizComponent = ({ courseId, moduleId, quiz, onComplete }: QuizComp
           {hasPassedBefore ? (
             <div className="mb-4">
               <Badge variant="default" className="mb-2">Quiz Passed</Badge>
-              <p className="text-sm text-muted-foreground">You've already passed this quiz!</p>
+              <p className="text-sm text-white/50">You've already passed this quiz!</p>
             </div>
           ) : (
             <div className="mb-4">

--- a/src/components/roadmap/FeatureSuggestionsList.tsx
+++ b/src/components/roadmap/FeatureSuggestionsList.tsx
@@ -43,7 +43,7 @@ export const FeatureSuggestionsList = ({
 
   if (loading) {
     return (
-      <Card className="border-border/50 h-full">
+      <Card className="border-white/8 h-full">
         <CardContent className="flex items-center justify-center py-10 px-4 h-full">
           <Loader2 className="w-6 h-6 animate-spin text-primary" />
         </CardContent>
@@ -53,11 +53,11 @@ export const FeatureSuggestionsList = ({
 
   if (suggestions.length === 0) {
     return (
-      <Card className="border-border/50 h-full">
+      <Card className="border-white/8 h-full">
         <CardContent className="flex flex-col items-center justify-center py-10 px-4 text-center gap-2 h-full">
-          <MessageSquare className="w-10 h-10 text-muted-foreground/50" />
-          <p className="text-sm font-medium text-muted-foreground">No community ideas yet</p>
-          <p className="text-xs text-muted-foreground/70">Be the first to submit one!</p>
+          <MessageSquare className="w-10 h-10 text-white/50" />
+          <p className="text-sm font-medium text-white/50">No community ideas yet</p>
+          <p className="text-xs text-white/70">Be the first to submit one!</p>
         </CardContent>
       </Card>
     );
@@ -65,7 +65,7 @@ export const FeatureSuggestionsList = ({
 
   return (
     <div className="h-full">
-      <Card className="border-border/50 h-full flex flex-col">
+      <Card className="border-white/8 h-full flex flex-col">
         <CardHeader className="pb-3 text-center flex-shrink-0">
           <CardTitle className="text-base md:text-lg flex flex-col items-center gap-2">
             <MessageSquare className="w-4 h-4 text-primary" />
@@ -86,7 +86,7 @@ export const FeatureSuggestionsList = ({
                   <button
                     key={suggestion.id}
                     onClick={() => setSelectedSuggestion(suggestion)}
-                    className="w-full p-4 rounded-lg border border-border/50 bg-card/50 hover:bg-muted/50 hover:border-primary/30 transition-all group"
+                    className="w-full p-4 rounded-lg border border-white/8 bg-card/50 hover:bg-white/5 hover:border-primary/30 transition-all group"
                   >
                     <div className="flex flex-col items-center gap-3 text-center">
                       <Badge variant="outline" className={`text-xs py-0.5 ${status.className}`}>
@@ -96,10 +96,10 @@ export const FeatureSuggestionsList = ({
                       <h4 className="font-medium text-sm break-words group-hover:text-primary transition-colors">
                         {suggestion.title}
                       </h4>
-                      <p className="text-xs text-muted-foreground line-clamp-2 break-words">
+                      <p className="text-xs text-white/50 line-clamp-2 break-words">
                         {suggestion.description}
                       </p>
-                      <div className="flex items-center justify-between w-full flex-wrap gap-2 text-xs text-muted-foreground/70 pt-1 border-t border-border/30">
+                      <div className="flex items-center justify-between w-full flex-wrap gap-2 text-xs text-white/70 pt-1 border-t border-white/8">
                         <span>by {suggestion.submitter_name}</span>
                         <span className="flex items-center gap-1">
                           Click to read more <ChevronRight className="w-3 h-3" />
@@ -136,7 +136,7 @@ export const FeatureSuggestionsList = ({
                       </Badge>
                     );
                   })()}
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-xs text-white/50">
                     {formatDistanceToNow(new Date(selectedSuggestion.created_at), { addSuffix: true })}
                   </span>
                 </div>
@@ -148,8 +148,8 @@ export const FeatureSuggestionsList = ({
                 </DialogDescription>
               </ScrollArea>
 
-              <div className="flex items-center justify-between pt-2 border-t border-border/50">
-                <span className="text-xs text-muted-foreground">
+              <div className="flex items-center justify-between pt-2 border-t border-white/8">
+                <span className="text-xs text-white/50">
                   Submitted by {selectedSuggestion.submitter_name}
                 </span>
                 {selectedSuggestion.status === 'promoted' && (

--- a/src/pages/AdvancedDefiProtocolsTutorial.tsx
+++ b/src/pages/AdvancedDefiProtocolsTutorial.tsx
@@ -975,7 +975,7 @@ const AdvancedDefiProtocolsTutorial = () => {
             </CardHeader>
 
             <CardContent className="space-y-6 tutorial-content-area">
-              <p className="text-muted-foreground leading-relaxed">{currentStepData.content.overview}</p>
+              <p className="text-white/50 leading-relaxed">{currentStepData.content.overview}</p>
 
               {/* Step 1: Advanced DeFi Landscape */}
               {currentStep === 1 && currentStepData.content.protocolCategories && (
@@ -986,7 +986,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                       {currentStepData.content.protocolCategories.map((cat: any, idx: number) => (
                         <Card key={idx} className="p-3 md:p-4">
                           <h4 className="font-semibold text-primary mb-2 text-sm md:text-base">{cat.category}</h4>
-                          <p className="text-xs md:text-sm text-muted-foreground mb-3">{cat.description}</p>
+                          <p className="text-xs md:text-sm text-white/50 mb-3">{cat.description}</p>
                           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs md:text-sm">
                             <div className="break-words"><span className="font-medium">Protocols:</span> {cat.protocols.join(', ')}</div>
                             <div><span className="font-medium">Yields:</span> {cat.yields}</div>
@@ -1020,7 +1020,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                           </div>
                           <p className="text-xs md:text-sm mb-2"><strong>Best for:</strong> {protocol.bestFor}</p>
                           <p className="text-xs md:text-sm mb-2 break-words"><strong>Features:</strong> {protocol.features.join(', ')}</p>
-                          <p className="text-xs text-muted-foreground break-words">{protocol.advantages.join(' • ')}</p>
+                          <p className="text-xs text-white/50 break-words">{protocol.advantages.join(' • ')}</p>
                         </Card>
                       ))}
                     </div>
@@ -1038,7 +1038,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                             <p className="text-xs md:text-sm mb-2">{strategy.description}</p>
                             <p className="text-xs md:text-sm text-primary mb-1 break-words"><strong>Example:</strong> {strategy.example}</p>
                             {strategy.considerations && (
-                              <p className="text-xs text-muted-foreground break-words">⚠️ {strategy.considerations.join(' • ')}</p>
+                              <p className="text-xs text-white/50 break-words">⚠️ {strategy.considerations.join(' • ')}</p>
                             )}
                           </Card>
                         ))}
@@ -1067,7 +1067,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                             <Badge className="w-fit text-xs">{protocol.riskLevel}</Badge>
                           </div>
                           <p className="text-xs md:text-sm mb-2">{protocol.specialty} (Max {protocol.maxLeverage})</p>
-                          <p className="text-xs text-muted-foreground mb-2 break-words">Pools: {protocol.supportedPools.join(', ')}</p>
+                          <p className="text-xs text-white/50 mb-2 break-words">Pools: {protocol.supportedPools.join(', ')}</p>
                           <p className="text-xs break-words">{protocol.features.join(' • ')}</p>
                         </Card>
                       ))}
@@ -1097,7 +1097,7 @@ const AdvancedDefiProtocolsTutorial = () => {
               {currentStep === 4 && currentStepData.content.majorProtocols && (
                 <div className="space-y-6">
                   {currentStepData.content.optionsBasics && (
-                    <Card className="p-4 bg-muted/50">
+                    <Card className="p-4 bg-white/5">
                       <h3 className="font-semibold mb-2">Options Basics</h3>
                       <div className="text-sm space-y-1">
                         <p>{currentStepData.content.optionsBasics.definition}</p>
@@ -1116,7 +1116,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                             <Badge className="w-fit text-xs">{protocol.liquidity} Liquidity</Badge>
                           </div>
                           <p className="text-xs md:text-sm mb-1">{protocol.type}</p>
-                          <p className="text-xs text-muted-foreground break-words">Assets: {protocol.assets.join(', ')}</p>
+                          <p className="text-xs text-white/50 break-words">Assets: {protocol.assets.join(', ')}</p>
                         </Card>
                       ))}
                     </div>
@@ -1129,7 +1129,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                           <Card key={idx} className="p-3 md:p-4">
                             <h4 className="font-semibold mb-2 text-sm md:text-base">{strategy.strategy}</h4>
                             <p className="text-xs md:text-sm mb-2">{strategy.description}</p>
-                            <div className="text-xs space-y-1 text-muted-foreground">
+                            <div className="text-xs space-y-1 text-white/50">
                               <p className="break-words"><strong>When:</strong> {strategy.when}</p>
                               <p className="break-words"><strong>How:</strong> {strategy.howItWorks}</p>
                               <p className="text-awareness break-words"><strong>Best for:</strong> {strategy.suitability}</p>
@@ -1146,10 +1146,10 @@ const AdvancedDefiProtocolsTutorial = () => {
               {currentStep === 5 && currentStepData.content.majorProtocols && (
                 <div className="space-y-6">
                   {currentStepData.content.syntheticsExplained && (
-                    <Card className="p-3 md:p-4 bg-muted/50">
+                    <Card className="p-3 md:p-4 bg-white/5">
                       <h3 className="font-semibold mb-2 text-sm md:text-base">What are Synthetics?</h3>
                       <p className="text-xs md:text-sm mb-2">{currentStepData.content.syntheticsExplained.definition}</p>
-                      <p className="text-xs text-muted-foreground break-words">Advantages: {currentStepData.content.syntheticsExplained.advantages.join(' • ')}</p>
+                      <p className="text-xs text-white/50 break-words">Advantages: {currentStepData.content.syntheticsExplained.advantages.join(' • ')}</p>
                     </Card>
                   )}
                   <div>
@@ -1161,7 +1161,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                           <div className="text-xs md:text-sm space-y-1">
                             <p className="break-words"><strong>Assets:</strong> {protocol.assets.join(', ')}</p>
                             <p className="break-words"><strong>Collateral:</strong> {protocol.collateral} ({protocol.collateralRatio})</p>
-                            <p className="text-xs text-muted-foreground break-words">{protocol.features.join(' • ')}</p>
+                            <p className="text-xs text-white/50 break-words">{protocol.features.join(' • ')}</p>
                           </div>
                         </Card>
                       ))}
@@ -1201,7 +1201,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                           </div>
                           <p className="text-xs md:text-sm mb-2">{approach.description}</p>
                           <p className="text-xs text-primary mb-1 break-words"><strong>Example:</strong> {approach.example}</p>
-                          <p className="text-xs text-muted-foreground break-words">Benefits: {approach.benefits.join(' • ')}</p>
+                          <p className="text-xs text-white/50 break-words">Benefits: {approach.benefits.join(' • ')}</p>
                         </Card>
                       ))}
                     </div>
@@ -1218,7 +1218,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                             </div>
                             <p className="text-xs md:text-sm mb-2 break-words">Protocols: {strategy.protocols.join(', ')}</p>
                             <p className="text-xs md:text-sm text-awareness mb-1"><strong>Target Yield:</strong> {strategy.targetYield}</p>
-                            <ul className="text-xs space-y-1 list-disc list-inside text-muted-foreground">
+                            <ul className="text-xs space-y-1 list-disc list-inside text-white/50">
                               {strategy.process.map((step: string, i: number) => (
                                 <li key={i} className="break-words">{step}</li>
                               ))}
@@ -1257,7 +1257,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                         {currentStepData.content.monitoringSystem.map((item: any, idx: number) => (
                           <Card key={idx} className="p-3 md:p-4">
                             <h4 className="font-semibold mb-1 text-sm md:text-base">{item.metric}</h4>
-                            <div className="text-xs space-y-1 text-muted-foreground">
+                            <div className="text-xs space-y-1 text-white/50">
                               <p><strong>Frequency:</strong> {item.frequency}</p>
                               <p><strong>Threshold:</strong> {item.threshold}</p>
                               <p className="break-words"><strong>Tools:</strong> {item.tools.join(', ')}</p>
@@ -1285,7 +1285,7 @@ const AdvancedDefiProtocolsTutorial = () => {
                           <div className="text-xs md:text-sm space-y-1">
                             <p><strong>Allocation:</strong> {value.allocation}</p>
                             <p><strong>Target APY:</strong> {value.targetAPY}</p>
-                            <p className="text-xs text-muted-foreground break-words">Strategies: {value.strategies.join(', ')}</p>
+                            <p className="text-xs text-white/50 break-words">Strategies: {value.strategies.join(', ')}</p>
                           </div>
                         </Card>
                       ))}

--- a/src/pages/ChartReadingTutorial.tsx
+++ b/src/pages/ChartReadingTutorial.tsx
@@ -45,21 +45,21 @@ const ChartReadingTutorial = () => {
                 <LineChart className="w-5 h-5 text-primary" />
                 <h4 className="font-semibold">Line Charts</h4>
               </div>
-              <p className="text-sm text-muted-foreground">Simple price movements over time, best for trend identification</p>
+              <p className="text-sm text-white/50">Simple price movements over time, best for trend identification</p>
             </Card>
             <Card className="p-4">
               <div className="flex items-center gap-3 mb-2">
                 <BarChart3 className="w-5 h-5 text-awareness" />
                 <h4 className="font-semibold">Candlestick Charts</h4>
               </div>
-              <p className="text-sm text-muted-foreground">Shows open, high, low, close prices: most detailed view</p>
+              <p className="text-sm text-white/50">Shows open, high, low, close prices: most detailed view</p>
             </Card>
             <Card className="p-4">
               <div className="flex items-center gap-3 mb-2">
                 <Activity className="w-5 h-5 text-accent" />
                 <h4 className="font-semibold">Volume Charts</h4>
               </div>
-              <p className="text-sm text-muted-foreground">Trading volume indicating market strength and conviction</p>
+              <p className="text-sm text-white/50">Trading volume indicating market strength and conviction</p>
             </Card>
           </div>
           
@@ -67,19 +67,19 @@ const ChartReadingTutorial = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="p-3 border rounded">
               <h5 className="font-medium text-sm">Short-term (1m to 1h)</h5>
-              <p className="text-xs text-muted-foreground">Day trading, quick entries/exits</p>
+              <p className="text-xs text-white/50">Day trading, quick entries/exits</p>
             </div>
             <div className="p-3 border rounded">
               <h5 className="font-medium text-sm">Medium-term (4h to 1d)</h5>
-              <p className="text-xs text-muted-foreground">Swing trading, position management</p>
+              <p className="text-xs text-white/50">Swing trading, position management</p>
             </div>
             <div className="p-3 border rounded">
               <h5 className="font-medium text-sm">Long-term (1w to 1M)</h5>
-              <p className="text-xs text-muted-foreground">Investment decisions, major trends</p>
+              <p className="text-xs text-white/50">Investment decisions, major trends</p>
             </div>
             <div className="p-3 border rounded">
               <h5 className="font-medium text-sm">Multi-timeframe</h5>
-              <p className="text-xs text-muted-foreground">Complete market picture</p>
+              <p className="text-xs text-white/50">Complete market picture</p>
             </div>
           </div>
         </div>
@@ -98,7 +98,7 @@ const ChartReadingTutorial = () => {
           <Card className="p-4 bg-awareness/10 border-awareness/20">
             <h4 className="font-semibold text-awareness mb-2">Support Levels</h4>
             <p className="text-sm text-foreground">Price levels where buying pressure is strong enough to prevent further decline</p>
-            <ul className="text-xs text-muted-foreground mt-2 space-y-1">
+            <ul className="text-xs text-white/50 mt-2 space-y-1">
               <li>• Previous lows that held multiple times</li>
               <li>• Round numbers (psychological levels)</li>
               <li>• Moving averages acting as dynamic support</li>
@@ -108,7 +108,7 @@ const ChartReadingTutorial = () => {
           <Card className="p-4 bg-destructive/10 border-destructive/20">
             <h4 className="font-semibold text-destructive mb-2">Resistance Levels</h4>
             <p className="text-sm text-foreground">Price levels where selling pressure prevents further upward movement</p>
-            <ul className="text-xs text-muted-foreground mt-2 space-y-1">
+            <ul className="text-xs text-white/50 mt-2 space-y-1">
               <li>• Previous highs that rejected price</li>
               <li>• Major round numbers</li>
               <li>• Trend lines and moving averages</li>
@@ -143,7 +143,7 @@ const ChartReadingTutorial = () => {
                 <h4 className="font-semibold text-awareness">Uptrend</h4>
               </div>
               <p className="text-sm mb-2">Higher highs and higher lows</p>
-              <div className="text-xs text-muted-foreground">
+              <div className="text-xs text-white/50">
                 <p>• Price consistently breaks above previous highs</p>
                 <p>• Pullbacks don't break previous support</p>
                 <p>• Increasing volume on upward moves</p>
@@ -156,7 +156,7 @@ const ChartReadingTutorial = () => {
                 <h4 className="font-semibold text-destructive">Downtrend</h4>
               </div>
               <p className="text-sm mb-2">Lower highs and lower lows</p>
-              <div className="text-xs text-muted-foreground">
+              <div className="text-xs text-white/50">
                 <p>• Price consistently breaks below previous lows</p>
                 <p>• Rallies fail at previous support (now resistance)</p>
                 <p>• Increasing volume on downward moves</p>
@@ -165,11 +165,11 @@ const ChartReadingTutorial = () => {
             
             <Card className="p-4">
               <div className="flex items-center gap-2 mb-2">
-                <Activity className="w-5 h-5 text-muted-foreground" />
+                <Activity className="w-5 h-5 text-white/50" />
                 <h4 className="font-semibold text-foreground">Sideways/Consolidation</h4>
               </div>
               <p className="text-sm mb-2">Price moves within a range</p>
-              <div className="text-xs text-muted-foreground">
+              <div className="text-xs text-white/50">
                 <p>• Price bounces between support and resistance</p>
                 <p>• No clear direction</p>
                 <p>• Often precedes major moves</p>
@@ -202,12 +202,12 @@ const ChartReadingTutorial = () => {
           <div className="space-y-4">
             <Card className="p-4">
               <h4 className="font-semibold mb-2">Moving Averages (MA)</h4>
-              <p className="text-sm text-muted-foreground mb-2">Smooth out price data to identify trend direction</p>
+              <p className="text-sm text-white/50 mb-2">Smooth out price data to identify trend direction</p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
-                <div className="p-2 bg-muted rounded">
+                <div className="p-2 bg-white/5 rounded">
                   <strong>Simple MA (SMA):</strong> Average of closing prices
                 </div>
-                <div className="p-2 bg-muted rounded">
+                <div className="p-2 bg-white/5 rounded">
                   <strong>Exponential MA (EMA):</strong> More weight on recent prices
                 </div>
               </div>
@@ -215,7 +215,7 @@ const ChartReadingTutorial = () => {
             
             <Card className="p-4">
               <h4 className="font-semibold mb-2">RSI (Relative Strength Index)</h4>
-              <p className="text-sm text-muted-foreground mb-2">Measures overbought/oversold conditions (0 to 100)</p>
+              <p className="text-sm text-white/50 mb-2">Measures overbought/oversold conditions (0 to 100)</p>
               <div className="flex flex-wrap gap-2">
                 <Badge variant="destructive" className="whitespace-nowrap">Oversold: &lt;30</Badge>
                 <Badge variant="secondary" className="whitespace-nowrap">Neutral: 30 to 70</Badge>
@@ -225,7 +225,7 @@ const ChartReadingTutorial = () => {
             
             <Card className="p-4">
               <h4 className="font-semibold mb-2">MACD (Moving Average Convergence Divergence)</h4>
-              <p className="text-sm text-muted-foreground mb-2">Shows relationship between two moving averages</p>
+              <p className="text-sm text-white/50 mb-2">Shows relationship between two moving averages</p>
               <ul className="text-xs space-y-1">
                 <li>• MACD line crossing above signal line = bullish</li>
                 <li>• MACD line crossing below signal line = bearish</li>
@@ -235,7 +235,7 @@ const ChartReadingTutorial = () => {
             
             <Card className="p-4">
               <h4 className="font-semibold mb-2">Volume Indicators</h4>
-              <p className="text-sm text-muted-foreground mb-2">Confirm price movements with volume analysis</p>
+              <p className="text-sm text-white/50 mb-2">Confirm price movements with volume analysis</p>
               <ul className="text-xs space-y-1">
                 <li>• High volume + price increase = strong bullish signal</li>
                 <li>• High volume + price decrease = strong bearish signal</li>
@@ -330,15 +330,15 @@ const ChartReadingTutorial = () => {
             <div className="space-y-3">
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Risk Per Trade: 1 to 2% of Portfolio</h5>
-                <p className="text-xs text-muted-foreground">Never risk more than you can afford to lose on a single trade</p>
+                <p className="text-xs text-white/50">Never risk more than you can afford to lose on a single trade</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Stop Loss Placement</h5>
-                <p className="text-xs text-muted-foreground">Use chart levels: below support for longs, above resistance for shorts</p>
+                <p className="text-xs text-white/50">Use chart levels: below support for longs, above resistance for shorts</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Risk-Reward Ratio</h5>
-                <p className="text-xs text-muted-foreground">Aim for minimum 1:2 ratio (risk $1 to make $2)</p>
+                <p className="text-xs text-white/50">Aim for minimum 1:2 ratio (risk $1 to make $2)</p>
               </div>
             </div>
           </Card>
@@ -348,7 +348,7 @@ const ChartReadingTutorial = () => {
             <div className="grid gap-3">
               <div className="p-3 bg-success/10 border border-success rounded">
                 <h5 className="font-medium text-sm text-success">Entry Signals</h5>
-                <ul className="text-xs text-muted-foreground mt-1 space-y-1">
+                <ul className="text-xs text-white/50 mt-1 space-y-1">
                   <li>• Breakout above resistance with volume</li>
                   <li>• Bounce off support level</li>
                   <li>• Pattern completion</li>
@@ -358,7 +358,7 @@ const ChartReadingTutorial = () => {
               
               <div className="p-3 bg-destructive/10 border border-destructive rounded">
                 <h5 className="font-medium text-sm text-destructive">Exit Signals</h5>
-                <ul className="text-xs text-muted-foreground mt-1 space-y-1">
+                <ul className="text-xs text-white/50 mt-1 space-y-1">
                   <li>• Price hits predetermined target</li>
                   <li>• Stop loss triggered</li>
                   <li>• Pattern failure or reversal</li>

--- a/src/pages/CrossChainBridgingTutorial.tsx
+++ b/src/pages/CrossChainBridgingTutorial.tsx
@@ -709,7 +709,7 @@ const CrossChainBridgingTutorial = () => {
             </div>
             <div>
               <h1 className="text-3xl font-bold">Cross-Chain Bridging Safely</h1>
-              <p className="text-muted-foreground">Master secure multi-chain DeFi navigation</p>
+              <p className="text-white/50">Master secure multi-chain DeFi navigation</p>
             </div>
           </div>
 
@@ -800,7 +800,7 @@ const CrossChainBridgingTutorial = () => {
             </CardHeader>
 
             <CardContent className="space-y-4 md:space-y-6 p-3 md:p-6">
-              <p className="text-muted-foreground text-sm md:text-base">{currentStepData.content.overview}</p>
+              <p className="text-white/50 text-sm md:text-base">{currentStepData.content.overview}</p>
 
               {/* Step 1: Understanding Bridges */}
               {currentStep === 1 && (
@@ -834,15 +834,15 @@ const CrossChainBridgingTutorial = () => {
                             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-2 md:gap-3 text-xs md:text-sm mb-3">
                               <div>
                                 <span className="font-medium">Speed:</span>
-                                <p className="text-muted-foreground">{bridge.speed}</p>
+                                <p className="text-white/50">{bridge.speed}</p>
                               </div>
                               <div>
                                 <span className="font-medium">Cost:</span>
-                                <p className="text-muted-foreground">{bridge.cost}</p>
+                                <p className="text-white/50">{bridge.cost}</p>
                               </div>
                               <div>
                                 <span className="font-medium">Best for:</span>
-                                <p className="text-muted-foreground">{bridge.bestFor}</p>
+                                <p className="text-white/50">{bridge.bestFor}</p>
                               </div>
                               <div>
                                 <span className="font-medium">Examples:</span>
@@ -875,15 +875,15 @@ const CrossChainBridgingTutorial = () => {
                             <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 md:gap-3 text-xs md:text-sm">
                               <div>
                                 <span className="font-medium">Fees: </span>
-                                <span className="text-muted-foreground">{chain.fees}</span>
+                                <span className="text-white/50">{chain.fees}</span>
                               </div>
                               <div>
                                 <span className="font-medium">Security: </span>
-                                <span className="text-muted-foreground">{chain.security}</span>
+                                <span className="text-white/50">{chain.security}</span>
                               </div>
                               <div>
                                 <span className="font-medium">Ecosystem: </span>
-                                <span className="text-muted-foreground">{chain.ecosystem}</span>
+                                <span className="text-white/50">{chain.ecosystem}</span>
                               </div>
                             </div>
                             <div className="mt-2">

--- a/src/pages/DaoParticipationTutorial.tsx
+++ b/src/pages/DaoParticipationTutorial.tsx
@@ -51,42 +51,42 @@ const DaoParticipationTutorial = () => {
                 <Users className="w-5 h-5 text-awareness" />
                 <h4 className="font-semibold">Decentralized Governance</h4>
               </div>
-              <p className="text-sm text-muted-foreground">No single entity controls decisions; power is distributed among token holders</p>
+              <p className="text-sm text-white/50">No single entity controls decisions; power is distributed among token holders</p>
             </Card>
             <Card className="p-4">
               <div className="flex items-center gap-3 mb-2">
                 <Shield className="w-5 h-5 text-primary" />
                 <h4 className="font-semibold">Transparent Operations</h4>
               </div>
-              <p className="text-sm text-muted-foreground">All activities and decisions are recorded on the blockchain</p>
+              <p className="text-sm text-white/50">All activities and decisions are recorded on the blockchain</p>
             </Card>
             <Card className="p-4">
               <div className="flex items-center gap-3 mb-2">
                 <Coins className="w-5 h-5 text-accent" />
                 <h4 className="font-semibold">Token-Based Voting</h4>
               </div>
-              <p className="text-sm text-muted-foreground">Governance tokens represent voting power and membership rights</p>
+              <p className="text-sm text-white/50">Governance tokens represent voting power and membership rights</p>
             </Card>
           </div>
           
           <div className="border rounded p-4">
             <h4 className="font-semibold mb-2">Types of DAOs</h4>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div className="p-2 bg-muted rounded">
+              <div className="p-2 bg-white/5 rounded">
                 <h5 className="font-medium text-sm">Protocol DAOs</h5>
-                <p className="text-xs text-muted-foreground">Govern DeFi protocols</p>
+                <p className="text-xs text-white/50">Govern DeFi protocols</p>
               </div>
-              <div className="p-2 bg-muted rounded">
+              <div className="p-2 bg-white/5 rounded">
                 <h5 className="font-medium text-sm">Investment DAOs</h5>
-                <p className="text-xs text-muted-foreground">Collective investment funds</p>
+                <p className="text-xs text-white/50">Collective investment funds</p>
               </div>
-              <div className="p-2 bg-muted rounded">
+              <div className="p-2 bg-white/5 rounded">
                 <h5 className="font-medium text-sm">Service DAOs</h5>
-                <p className="text-xs text-muted-foreground">Provide services to Web3</p>
+                <p className="text-xs text-white/50">Provide services to Web3</p>
               </div>
-              <div className="p-2 bg-muted rounded">
+              <div className="p-2 bg-white/5 rounded">
                 <h5 className="font-medium text-sm">Social DAOs</h5>
-                <p className="text-xs text-muted-foreground">Community-focused</p>
+                <p className="text-xs text-white/50">Community-focused</p>
               </div>
             </div>
           </div>
@@ -106,7 +106,7 @@ const DaoParticipationTutorial = () => {
           <div className="grid gap-4">
             <Card className="p-4">
               <h4 className="font-semibold mb-2">Purchase on Exchanges</h4>
-              <p className="text-sm text-muted-foreground mb-2">Buy tokens directly from centralized or decentralized exchanges</p>
+              <p className="text-sm text-white/50 mb-2">Buy tokens directly from centralized or decentralized exchanges</p>
               <ul className="text-xs space-y-1">
                 <li>• Check major exchanges like Coinbase, Binance</li>
                 <li>• Use DEXs like Uniswap, SushiSwap</li>
@@ -116,7 +116,7 @@ const DaoParticipationTutorial = () => {
             
             <Card className="p-4">
               <h4 className="font-semibold mb-2">Participate in Protocol</h4>
-              <p className="text-sm text-muted-foreground mb-2">Earn tokens through active participation</p>
+              <p className="text-sm text-white/50 mb-2">Earn tokens through active participation</p>
               <ul className="text-xs space-y-1">
                 <li>• Provide liquidity to earn tokens</li>
                 <li>• Use the protocol's services</li>
@@ -126,7 +126,7 @@ const DaoParticipationTutorial = () => {
             
             <Card className="p-4">
               <h4 className="font-semibold mb-2">Airdrops</h4>
-              <p className="text-sm text-muted-foreground mb-2">Receive free tokens for early participation</p>
+              <p className="text-sm text-white/50 mb-2">Receive free tokens for early participation</p>
               <ul className="text-xs space-y-1">
                 <li>• Follow project announcements</li>
                 <li>• Meet eligibility criteria</li>
@@ -162,19 +162,19 @@ const DaoParticipationTutorial = () => {
             <div className="space-y-3">
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Title & Summary</h5>
-                <p className="text-xs text-muted-foreground">Brief description of what's being proposed</p>
+                <p className="text-xs text-white/50">Brief description of what's being proposed</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Background & Motivation</h5>
-                <p className="text-xs text-muted-foreground">Why this change is needed</p>
+                <p className="text-xs text-white/50">Why this change is needed</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Specification</h5>
-                <p className="text-xs text-muted-foreground">Technical details of the implementation</p>
+                <p className="text-xs text-white/50">Technical details of the implementation</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Impact Analysis</h5>
-                <p className="text-xs text-muted-foreground">Expected effects on the protocol and users</p>
+                <p className="text-xs text-white/50">Expected effects on the protocol and users</p>
               </div>
             </div>
           </Card>
@@ -231,7 +231,7 @@ const DaoParticipationTutorial = () => {
                 <Vote className="w-5 h-5 text-primary" />
                 <h4 className="font-semibold">Voting Power</h4>
               </div>
-              <p className="text-sm text-muted-foreground mb-2">Your voting power is typically proportional to your token holdings</p>
+              <p className="text-sm text-white/50 mb-2">Your voting power is typically proportional to your token holdings</p>
               <ul className="text-xs space-y-1">
                 <li>• 1 token = 1 vote (most common)</li>
                 <li>• Some DAOs use quadratic voting</li>
@@ -263,19 +263,19 @@ const DaoParticipationTutorial = () => {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Snapshot</h5>
-                <p className="text-xs text-muted-foreground">Off-chain voting (gas-free)</p>
+                <p className="text-xs text-white/50">Off-chain voting (gas-free)</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Tally</h5>
-                <p className="text-xs text-muted-foreground">On-chain governance dashboard</p>
+                <p className="text-xs text-white/50">On-chain governance dashboard</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Governor Alpha/Bravo</h5>
-                <p className="text-xs text-muted-foreground">On-chain voting contracts</p>
+                <p className="text-xs text-white/50">On-chain voting contracts</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Commonwealth</h5>
-                <p className="text-xs text-muted-foreground">Discussion & voting platform</p>
+                <p className="text-xs text-white/50">Discussion & voting platform</p>
               </div>
             </div>
           </Card>
@@ -309,15 +309,15 @@ const DaoParticipationTutorial = () => {
               <div className="space-y-2">
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Discord/Forum Participation</h5>
-                  <p className="text-xs text-muted-foreground">Join discussions, ask questions, share insights</p>
+                  <p className="text-xs text-white/50">Join discussions, ask questions, share insights</p>
                 </div>
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Working Groups</h5>
-                  <p className="text-xs text-muted-foreground">Contribute to specific initiatives and projects</p>
+                  <p className="text-xs text-white/50">Contribute to specific initiatives and projects</p>
                 </div>
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Proposal Writing</h5>
-                  <p className="text-xs text-muted-foreground">Draft and submit your own proposals</p>
+                  <p className="text-xs text-white/50">Draft and submit your own proposals</p>
                 </div>
               </div>
             </Card>
@@ -350,15 +350,15 @@ const DaoParticipationTutorial = () => {
             <div className="space-y-3">
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Committee Member</h5>
-                <p className="text-xs text-muted-foreground">Join governance, treasury, or technical committees</p>
+                <p className="text-xs text-white/50">Join governance, treasury, or technical committees</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Delegate</h5>
-                <p className="text-xs text-muted-foreground">Receive delegated voting power from others</p>
+                <p className="text-xs text-white/50">Receive delegated voting power from others</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Steward/Guardian</h5>
-                <p className="text-xs text-muted-foreground">Take on formal leadership roles</p>
+                <p className="text-xs text-white/50">Take on formal leadership roles</p>
               </div>
             </div>
           </Card>
@@ -451,7 +451,7 @@ const DaoParticipationTutorial = () => {
           
           <Card className="p-4 bg-success/10 border-success">
             <h4 className="font-semibold text-foreground mb-2">Best Practices</h4>
-            <ul className="text-sm text-muted-foreground space-y-1">
+            <ul className="text-sm text-white/50 space-y-1">
               <li>• Start with smaller, established DAOs to learn</li>
               <li>• Diversify across multiple DAOs to reduce risk</li>
               <li>• Stay informed about governance developments</li>

--- a/src/pages/DefiCalculatorsTutorial.tsx
+++ b/src/pages/DefiCalculatorsTutorial.tsx
@@ -416,7 +416,7 @@ const DefiCalculatorsTutorial = () => {
             </div>
             <div>
               <h1 className="text-3xl font-bold">Using DeFi Calculators</h1>
-              <p className="text-muted-foreground">Master the tools for smart DeFi investing</p>
+              <p className="text-white/50">Master the tools for smart DeFi investing</p>
             </div>
           </div>
 
@@ -506,7 +506,7 @@ const DefiCalculatorsTutorial = () => {
             </CardHeader>
 
             <CardContent className="space-y-6">
-              <p className="text-muted-foreground">{currentStepData.content.overview}</p>
+              <p className="text-white/50">{currentStepData.content.overview}</p>
 
               {/* Step 1: Understanding Calculators */}
               {currentStep === 1 && (
@@ -530,11 +530,11 @@ const DefiCalculatorsTutorial = () => {
                             <div className="space-y-3 text-sm">
                               <div>
                                 <p className="font-medium mb-1">When to use:</p>
-                                <p className="text-muted-foreground">{calc.when}</p>
+                                <p className="text-white/50">{calc.when}</p>
                               </div>
                               <div>
                                 <p className="font-medium mb-1">How it helps:</p>
-                                <p className="text-muted-foreground">{calc.helps}</p>
+                                <p className="text-white/50">{calc.helps}</p>
                               </div>
                             </div>
                           </CardContent>
@@ -652,15 +652,15 @@ const DefiCalculatorsTutorial = () => {
                         <div className="space-y-4">
                           <h4 className="font-semibold">Results:</h4>
                           <div className="space-y-3">
-                            <div className="flex justify-between items-center p-3 bg-muted rounded-lg">
+                            <div className="flex justify-between items-center p-3 bg-white/5 rounded-lg">
                               <span className="font-medium">Final Amount:</span>
                               <span className="text-awareness font-bold">${yieldResults.finalAmount}</span>
                             </div>
-                            <div className="flex justify-between items-center p-3 bg-muted rounded-lg">
+                            <div className="flex justify-between items-center p-3 bg-white/5 rounded-lg">
                               <span className="font-medium">Total Return:</span>
                               <span className="text-awareness font-bold">${yieldResults.totalReturn}</span>
                             </div>
-                            <div className="flex justify-between items-center p-3 bg-muted rounded-lg">
+                            <div className="flex justify-between items-center p-3 bg-white/5 rounded-lg">
                               <span className="font-medium">Effective APY:</span>
                               <span className="text-awareness font-bold">{yieldResults.effectiveAPY}%</span>
                             </div>
@@ -678,7 +678,7 @@ const DefiCalculatorsTutorial = () => {
                         <Card key={index}>
                           <CardContent className="p-4">
                             <h4 className="font-medium mb-2">{input.name}</h4>
-                            <p className="text-sm text-muted-foreground mb-2">{input.description}</p>
+                            <p className="text-sm text-white/50 mb-2">{input.description}</p>
                             <div className="flex items-center justify-between text-sm">
                               <span className="text-primary">Example: {input.example}</span>
                               <span className="text-awareness">💡 {input.tips}</span>
@@ -697,7 +697,7 @@ const DefiCalculatorsTutorial = () => {
                         <Card key={index}>
                           <CardContent className="p-4">
                             <h4 className="font-medium mb-2">{result.metric}</h4>
-                            <p className="text-sm text-muted-foreground mb-2">{result.meaning}</p>
+                            <p className="text-sm text-white/50 mb-2">{result.meaning}</p>
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
                               <div className="flex items-center gap-2">
                                 <CheckCircle className="h-3 w-3 text-awareness" />
@@ -898,13 +898,13 @@ const DefiCalculatorsTutorial = () => {
                             </div>
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
                               <div>
-                                <span className="text-muted-foreground">Token A:</span> {scenario.tokenA}
+                                <span className="text-white/50">Token A:</span> {scenario.tokenA}
                               </div>
                               <div>
-                                <span className="text-muted-foreground">Token B:</span> {scenario.tokenB}
+                                <span className="text-white/50">Token B:</span> {scenario.tokenB}
                               </div>
                             </div>
-                            <p className="text-sm text-muted-foreground">{scenario.meaning}</p>
+                            <p className="text-sm text-white/50">{scenario.meaning}</p>
                           </CardContent>
                         </Card>
                       ))}
@@ -945,7 +945,7 @@ const DefiCalculatorsTutorial = () => {
                         <Card key={index}>
                           <CardContent className="p-4">
                             <h4 className="font-medium mb-2 text-success">{practice.practice}</h4>
-                            <p className="text-sm text-muted-foreground mb-2">{practice.reason}</p>
+                            <p className="text-sm text-white/50 mb-2">{practice.reason}</p>
                             <div className="flex items-center gap-2 text-sm text-accent">
                               <Target className="h-3 w-3" />
                               <span>Action: {practice.action}</span>

--- a/src/pages/DefiVaultsExplained.tsx
+++ b/src/pages/DefiVaultsExplained.tsx
@@ -59,11 +59,11 @@ const DefiVaultsExplained = () => {
               Listen to this article
             </button>
 
-            <p className="text-lg text-muted-foreground font-consciousness mb-6 leading-relaxed">
+            <p className="text-lg text-white/50 font-consciousness mb-6 leading-relaxed">
               {blogPost.excerpt}
             </p>
 
-            <div className="flex flex-wrap items-center gap-6 text-sm text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-6 text-sm text-white/50">
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4" />
                 <span>{BRAND_AUTHOR}</span>
@@ -109,7 +109,7 @@ const DefiVaultsExplained = () => {
                   Unlike traditional investment funds, everything about a DeFi vault is transparent:
                 </p>
 
-                <div className="bg-muted/30 rounded-lg p-6 mb-6">
+                <div className="bg-white/5 rounded-lg p-6 mb-6">
                   <ul className="space-y-3 text-foreground/90">
                     <li><strong className="text-foreground">The Strategy:</strong> The exact rules are written in open-source code that anyone can read</li>
                     <li><strong className="text-foreground">The Holdings:</strong> Every asset the vault holds is visible on the blockchain in real-time</li>
@@ -179,7 +179,7 @@ const DefiVaultsExplained = () => {
                   </div>
                 </div>
 
-                <div className="bg-muted/30 rounded-lg p-6 mb-6">
+                <div className="bg-white/5 rounded-lg p-6 mb-6">
                   <h3 className="text-xl font-semibold text-foreground mb-4">The 2022 CeFi Collapse: A Case Study</h3>
                   <ul className="space-y-3 text-foreground/90">
                     <li><strong className="text-foreground">Celsius Network:</strong> Halted withdrawals and filed bankruptcy, revealing a $4.7 billion hole that customers never saw coming</li>
@@ -206,28 +206,28 @@ const DefiVaultsExplained = () => {
                 </p>
 
                 <div className="grid md:grid-cols-2 gap-6 mb-6">
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">On-Chain Visibility</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       At any moment, you can see exactly what assets the vault holds. Not a quarterly report, not a delayed disclosure, but the actual current state of the portfolio.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Transaction History</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Every trade, every yield harvest, every fee payment is recorded on the blockchain forever. You can trace exactly what happened with your money at any point.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Open-Source Code</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       The vault's strategy is literally written in code that anyone can read. If the vault claims to invest only in blue-chip protocols, you can verify this by examining the smart contract.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Self-Custody</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Your assets are held by the smart contract, not by a company. The contract enforces the rules, and only you can withdraw your share.
@@ -280,33 +280,33 @@ const DefiVaultsExplained = () => {
                 </div>
 
                 {/* Comparison Table */}
-                <div className="bg-muted/30 rounded-lg p-6 mb-6 overflow-x-auto">
+                <div className="bg-white/5 rounded-lg p-6 mb-6 overflow-x-auto">
                   <h3 className="text-xl font-semibold text-foreground mb-4">Traditional Fund vs. DeFi Vault</h3>
                   <table className="w-full text-sm">
                     <thead>
-                      <tr className="border-b border-border">
+                      <tr className="border-b border-white/8">
                         <th className="text-left py-3 text-foreground font-semibold">Aspect</th>
                         <th className="text-left py-3 text-foreground font-semibold">Traditional Fund</th>
                         <th className="text-left py-3 text-foreground font-semibold">DeFi Vault</th>
                       </tr>
                     </thead>
                     <tbody className="text-foreground/80">
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Strategy Execution</td>
                         <td className="py-3">Manager discretion</td>
                         <td className="py-3">Smart contract code</td>
                       </tr>
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Rule Enforcement</td>
                         <td className="py-3">Trust-based</td>
                         <td className="py-3">Code-enforced</td>
                       </tr>
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Strategy Changes</td>
                         <td className="py-3">Manager can change anytime</td>
                         <td className="py-3">Requires governance</td>
                       </tr>
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Verification</td>
                         <td className="py-3">Periodic reports</td>
                         <td className="py-3">Real-time on-chain</td>
@@ -335,28 +335,28 @@ const DefiVaultsExplained = () => {
                 </p>
 
                 <div className="grid md:grid-cols-2 gap-6 mb-6">
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Yield Aggregator Vaults</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Automatically move capital between yield-generating protocols to maximize returns. Examples include Yearn Finance vaults.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Lending Vaults</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Participate in decentralized lending markets, earning interest on deposited assets through protocols like Aave and Compound.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Liquidity Provider Vaults</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Provide liquidity to DEXs and earn trading fees, with strategies to minimize impermanent loss.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Delta-Neutral Vaults</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Generate yield while minimizing price exposure through hedging strategies that maintain market-neutral positions.
@@ -423,7 +423,7 @@ const DefiVaultsExplained = () => {
                 </p>
 
                 <div className="grid md:grid-cols-2 gap-6">
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Security</h3>
                     <ul className="space-y-2 text-foreground/80 text-sm">
                       <li>• Has the smart contract been audited?</li>
@@ -432,7 +432,7 @@ const DefiVaultsExplained = () => {
                     </ul>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Strategy</h3>
                     <ul className="space-y-2 text-foreground/80 text-sm">
                       <li>• Can you understand how it generates returns?</li>
@@ -441,7 +441,7 @@ const DefiVaultsExplained = () => {
                     </ul>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Transparency</h3>
                     <ul className="space-y-2 text-foreground/80 text-sm">
                       <li>• Is the code open-source and verified?</li>
@@ -450,7 +450,7 @@ const DefiVaultsExplained = () => {
                     </ul>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Governance</h3>
                     <ul className="space-y-2 text-foreground/80 text-sm">
                       <li>• Who built and maintains the vault?</li>
@@ -487,8 +487,8 @@ const DefiVaultsExplained = () => {
               </div>
 
               {/* Disclaimer */}
-              <div className="border-t border-border pt-8">
-                <p className="text-sm text-muted-foreground italic leading-relaxed">
+              <div className="border-t border-white/8 pt-8">
+                <p className="text-sm text-white/50 italic leading-relaxed">
                   This content is provided for educational purposes only. It does not constitute financial advice. All investments involve risk, including potential loss of principal. Always conduct your own research and consult with qualified professionals before making investment decisions. Past performance is not indicative of future results.
                 </p>
               </div>

--- a/src/pages/FirstDexSwapTutorial.tsx
+++ b/src/pages/FirstDexSwapTutorial.tsx
@@ -500,7 +500,7 @@ const FirstDexSwapTutorial = () => {
         {/* Back to Tutorials Button */}
         <div className="mb-6">
           <Link to="/tutorials">
-            <Button variant="ghost" className="gap-2 hover:bg-muted">
+            <Button variant="ghost" className="gap-2 hover:bg-white/5">
               <ArrowLeft className="h-4 w-4" />
               Back to Tutorials
             </Button>
@@ -527,7 +527,7 @@ const FirstDexSwapTutorial = () => {
               </div>
               <div>
                 <h1 className="text-2xl md:text-3xl font-bold">Your First DEX Swap</h1>
-                <p className="text-sm md:text-base text-muted-foreground">Step-by-step guide to safe decentralized trading</p>
+                <p className="text-sm md:text-base text-white/50">Step-by-step guide to safe decentralized trading</p>
               </div>
             </div>
 
@@ -620,7 +620,7 @@ const FirstDexSwapTutorial = () => {
             </CardHeader>
 
             <CardContent className="space-y-4 md:space-y-6 p-3 md:p-6">
-              <p className="text-sm md:text-base text-muted-foreground text-center sm:text-left">{currentStepData.content.overview}</p>
+              <p className="text-sm md:text-base text-white/50 text-center sm:text-left">{currentStepData.content.overview}</p>
 
               {/* Step 1: Choose DEX */}
               {currentStep === 1 && (
@@ -671,9 +671,9 @@ const FirstDexSwapTutorial = () => {
                             </ul>
                           </div>
                         </div>
-                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <div className="flex items-center gap-2 text-sm text-white/50">
                           <Globe className="h-4 w-4" />
-                          <code className="bg-muted px-2 py-1 rounded">{dex.url}</code>
+                          <code className="bg-white/5 px-2 py-1 rounded">{dex.url}</code>
                         </div>
                       </CardContent>
                     </Card>
@@ -914,7 +914,7 @@ const FirstDexSwapTutorial = () => {
                               <h4 className="font-medium">{item.item}</h4>
                               <CheckCircle className="h-4 w-4 text-awareness" />
                             </div>
-                            <p className="text-sm text-muted-foreground mb-2">{item.description}</p>
+                            <p className="text-sm text-white/50 mb-2">{item.description}</p>
                             <div className="flex items-center gap-2 text-sm text-destructive">
                               <AlertTriangle className="h-3 w-3" />
                               <span>Red flag: {item.redFlag}</span>
@@ -935,7 +935,7 @@ const FirstDexSwapTutorial = () => {
                               <h4 className="font-medium">{setting.setting}</h4>
                               <Badge variant="outline">{setting.recommended}</Badge>
                             </div>
-                            <p className="text-sm text-muted-foreground">{setting.description}</p>
+                            <p className="text-sm text-white/50">{setting.description}</p>
                           </CardContent>
                         </Card>
                       ))}
@@ -959,7 +959,7 @@ const FirstDexSwapTutorial = () => {
                               </Badge>
                               <div className="flex-1">
                                 <h4 className="font-medium">{step.step}</h4>
-                                <p className="text-sm text-muted-foreground">{step.description}</p>
+                                <p className="text-sm text-white/50">{step.description}</p>
                               </div>
                             </div>
                             <div className="flex items-center gap-2 text-sm text-primary ml-9">
@@ -1021,7 +1021,7 @@ const FirstDexSwapTutorial = () => {
                     </CardHeader>
                     <CardContent>
                       <p className="text-sm mb-3">
-                        Visit <code className="bg-muted text-muted-foreground px-2 py-1 rounded">{currentStepData.content.transactionExplorer?.url}</code> to verify your transaction.
+                        Visit <code className="bg-white/5 text-white/50 px-2 py-1 rounded">{currentStepData.content.transactionExplorer?.url}</code> to verify your transaction.
                       </p>
                       <div className="space-y-2">
                         <h4 className="font-medium">What to check:</h4>
@@ -1044,7 +1044,7 @@ const FirstDexSwapTutorial = () => {
                         <Card key={index}>
                           <CardContent className="p-4">
                             <h4 className="font-medium mb-2">{practice.practice}</h4>
-                            <p className="text-sm text-muted-foreground mb-2">{practice.reason}</p>
+                            <p className="text-sm text-white/50 mb-2">{practice.reason}</p>
                             <div className="flex items-center gap-2 text-sm text-primary">
                               <TrendingUp className="h-3 w-3" />
                               <span>How: {practice.how}</span>

--- a/src/pages/LiquidStakingTokens2025.tsx
+++ b/src/pages/LiquidStakingTokens2025.tsx
@@ -51,11 +51,11 @@ const LiquidStakingTokens2025 = () => {
               Listen to this article
             </button>
 
-            <p className="text-lg text-muted-foreground font-consciousness mb-6 leading-relaxed">
+            <p className="text-lg text-white/50 font-consciousness mb-6 leading-relaxed">
               {blogPost.excerpt}
             </p>
 
-            <div className="flex flex-wrap items-center gap-6 text-sm text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-6 text-sm text-white/50">
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4" />
                 <span>{BRAND_AUTHOR}</span>
@@ -75,25 +75,25 @@ const LiquidStakingTokens2025 = () => {
             <div className="space-y-6 text-foreground">
               <section>
                 <h2 className="text-2xl font-bold mb-4 text-foreground">What Are Liquid Staking Tokens?</h2>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-white/50 leading-relaxed">
                   Liquid Staking Tokens (LSTs) represent a paradigm shift in how we think about Ethereum staking. When you stake ETH traditionally, your capital gets locked: earning yield but sacrificing liquidity. LSTs solve this elegantly: stake your ETH, receive a liquid token (like stETH or rETH) that represents your staked position, and continue using that token across DeFi protocols. It's the best of both worlds: earning staking rewards while maintaining capital flexibility.
                 </p>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-white/50 leading-relaxed">
                   In 2025, LSTs have evolved from a novel experiment to a foundational DeFi primitive, with over $40 billion in total value locked across major protocols. They're not just popular: they're reshaping how institutional and retail investors approach crypto yield generation.
                 </p>
               </section>
 
               <section>
                 <h2 className="text-2xl font-bold mb-4 text-foreground">Why Liquid Staking Tokens Matter</h2>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-white/50 leading-relaxed">
                   The brilliance of LSTs lies in their triple value proposition:
                 </p>
-                <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <ul className="list-disc pl-6 space-y-2 text-white/50">
                   <li><strong className="text-foreground">Yield Generation:</strong> Earn native Ethereum staking rewards (4 to 6% APY) simply by holding the token.</li>
                   <li><strong className="text-foreground">Liquidity Preservation:</strong> Unlike locked staking, LSTs can be traded, sold, or transferred instantly on any DEX.</li>
                   <li><strong className="text-foreground">Composability:</strong> Deploy your LSTs as collateral in lending protocols, liquidity pools, or yield farming strategies: stacking multiple yield sources simultaneously.</li>
                 </ul>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-white/50 leading-relaxed">
                   This composability unlocks strategies previously impossible: imagine earning 5% from ETH staking, another 8% from providing liquidity on Curve, and 3% from lending on Aave: all from the same capital. That's the power of liquid staking in action.
                 </p>
               </section>
@@ -107,7 +107,7 @@ const LiquidStakingTokens2025 = () => {
                         Lido Finance <ExternalLink className="w-4 h-4" />
                       </a>
                     </h3>
-                    <p className="text-muted-foreground">
+                    <p className="text-white/50">
                       The market leader with over 30% of all staked ETH. Lido's stETH token maintains deep liquidity across major DEXs and is accepted as collateral on virtually every DeFi platform. Their decentralized validator network and battle-tested smart contracts make stETH the gold standard for liquid staking.
                     </p>
                   </div>
@@ -117,7 +117,7 @@ const LiquidStakingTokens2025 = () => {
                         Rocket Pool <ExternalLink className="w-4 h-4" />
                       </a>
                     </h3>
-                    <p className="text-muted-foreground">
+                    <p className="text-white/50">
                       The decentralization champion. Rocket Pool's rETH prioritizes censorship resistance with permissionless node operators and lower capital requirements. Perfect for users who value Ethereum's core ethos alongside competitive yields.
                     </p>
                   </div>
@@ -127,7 +127,7 @@ const LiquidStakingTokens2025 = () => {
                         EigenLayer <ExternalLink className="w-4 h-4" />
                       </a>
                     </h3>
-                    <p className="text-muted-foreground">
+                    <p className="text-white/50">
                       The innovation frontier. EigenLayer introduces "restaking": allowing LST holders to secure additional protocols beyond Ethereum, earning extra yield streams. It's composability taken to the next level, though with correspondingly higher complexity and risk.
                     </p>
                   </div>
@@ -139,7 +139,7 @@ const LiquidStakingTokens2025 = () => {
                 <div className="grid md:grid-cols-2 gap-6">
                   <div>
                     <h3 className="text-lg font-semibold mb-3 text-primary">Opportunities</h3>
-                    <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                    <ul className="list-disc pl-6 space-y-2 text-white/50">
                       <li>Passive income without sacrificing capital efficiency</li>
                       <li>Portfolio diversification through multi-strategy yield stacking</li>
                       <li>Growing institutional adoption legitimizing the sector</li>
@@ -148,7 +148,7 @@ const LiquidStakingTokens2025 = () => {
                   </div>
                   <div>
                     <h3 className="text-lg font-semibold mb-3 text-destructive">Risks</h3>
-                    <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                    <ul className="list-disc pl-6 space-y-2 text-white/50">
                       <li><strong className="text-foreground">Centralization concerns:</strong> Large protocols controlling validator sets could threaten Ethereum's neutrality</li>
                       <li><strong className="text-foreground">Smart contract vulnerabilities:</strong> Complex protocols mean larger attack surfaces: audits don't eliminate risk</li>
                       <li><strong className="text-foreground">Liquidity crunches:</strong> During market stress, LST/ETH peg can break, causing cascade liquidations</li>
@@ -156,27 +156,27 @@ const LiquidStakingTokens2025 = () => {
                     </ul>
                   </div>
                 </div>
-                <p className="text-muted-foreground leading-relaxed mt-4">
+                <p className="text-white/50 leading-relaxed mt-4">
                   Smart users diversify across multiple LST protocols, never allocate more than they can afford to lose, and continuously monitor protocol health metrics.
                 </p>
               </section>
 
               <section>
                 <h2 className="text-2xl font-bold mb-4 text-foreground">The Future: DeFi Summer 2.0?</h2>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-white/50 leading-relaxed">
                   Analysts aren't exaggerating when they call this DeFi Summer 2.0. The 2020 DeFi boom was about yield farming and governance tokens. The 2025 LST wave is more mature: institutional-grade infrastructure, regulatory clarity emerging, and sustainable yield models replacing unsustainable token emissions.
                 </p>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-white/50 leading-relaxed">
                   Ethereum's roadmap strengthens the thesis: increased validator limits, improved withdrawal mechanisms, and layer-2 scaling all enhance LST utility. Meanwhile, traditional finance institutions are exploring LSTs as fixed-income alternatives in their digital asset portfolios.
                 </p>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-white/50 leading-relaxed">
                   The convergence of liquid staking, restaking, and cross-chain bridges hints at a future where crypto capital flows effortlessly across ecosystems, maximizing efficiency while managing risk programmatically. That future is being built today.
                 </p>
               </section>
 
               <section className="bg-primary/5 p-6 rounded-lg border border-primary/20 mt-8">
                 <h2 className="text-2xl font-bold mb-4 text-foreground">Explore DeFi with 3rdeyeadvisors</h2>
-                <p className="text-muted-foreground leading-relaxed mb-4">
+                <p className="text-white/50 leading-relaxed mb-4">
                   Ready to navigate the evolving DeFi landscape with confidence? 3rdeyeadvisors provides cutting-edge education, risk frameworks, and strategic insights for both newcomers and experienced yield farmers. From LST comparison guides to portfolio optimization tools, we help you make informed decisions in this fast-moving space.
                 </p>
                 <a 

--- a/src/pages/LiquidityPoolBasicsTutorial.tsx
+++ b/src/pages/LiquidityPoolBasicsTutorial.tsx
@@ -577,7 +577,7 @@ const LiquidityPoolBasicsTutorial = () => {
         {/* Header */}
         <div className="mb-8">
           <Link to="/tutorials?tab=practical">
-            <Button variant="ghost" className="mb-4 hover:bg-muted/50">
+            <Button variant="ghost" className="mb-4 hover:bg-white/5">
               <ArrowLeft className="mr-2 h-4 w-4" />
               Back to Practical DeFi Actions
             </Button>
@@ -589,14 +589,14 @@ const LiquidityPoolBasicsTutorial = () => {
             </div>
             <div>
               <h1 className="text-2xl md:text-3xl font-bold text-foreground">Liquidity Pool Basics</h1>
-              <p className="text-sm md:text-base text-muted-foreground">Understanding and participating in liquidity pools safely</p>
+              <p className="text-sm md:text-base text-white/50">Understanding and participating in liquidity pools safely</p>
             </div>
           </div>
 
           {/* Progress Bar */}
           <div className="space-y-2">
             <div className="flex justify-between text-xs md:text-sm">
-              <span className="text-muted-foreground">
+              <span className="text-white/50">
                 Step {currentStep} of {totalSteps}
               </span>
               <span className="text-primary font-medium">{Math.round(progress)}% Complete</span>
@@ -630,7 +630,7 @@ const LiquidityPoolBasicsTutorial = () => {
 
         {/* Current Step Card */}
         <Card className="mb-6 border-primary/20 shadow-lg">
-          <CardHeader className="border-b border-border/50 bg-gradient-to-br from-card via-card to-primary/5 p-3 md:p-6">
+          <CardHeader className="border-b border-white/8 bg-gradient-to-br from-card via-card to-primary/5 p-3 md:p-6">
             <div className="flex flex-col gap-3">
               <div className="flex flex-col items-center gap-3 md:flex-row md:justify-between">
                 <div className="flex items-center gap-3">
@@ -662,14 +662,14 @@ const LiquidityPoolBasicsTutorial = () => {
               <div className="space-y-6">
                 <div className="space-y-3">
                   <h3 className="font-semibold text-foreground text-lg">What Is a Liquidity Pool?</h3>
-                  <div className="bg-muted/30 rounded-lg p-4 space-y-3">
-                    <p className="text-sm text-muted-foreground leading-relaxed">
+                  <div className="bg-white/5 rounded-lg p-4 space-y-3">
+                    <p className="text-sm text-white/50 leading-relaxed">
                       <strong>Simple:</strong> {currentStepData.content.definition.simple}
                     </p>
-                    <p className="text-sm text-muted-foreground leading-relaxed">
+                    <p className="text-sm text-white/50 leading-relaxed">
                       <strong>Technical:</strong> {currentStepData.content.definition.technical}
                     </p>
-                    <p className="text-sm text-muted-foreground leading-relaxed">
+                    <p className="text-sm text-white/50 leading-relaxed">
                       <strong>Analogy:</strong> {currentStepData.content.definition.analogy}
                     </p>
                   </div>
@@ -679,9 +679,9 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Key Components</h3>
                   <div className="grid gap-3">
                     {currentStepData.content.keyComponents.map((comp, idx) => (
-                      <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-2">{comp.component}</h4>
-                        <p className="text-sm text-muted-foreground mb-2">{comp.description}</p>
+                        <p className="text-sm text-white/50 mb-2">{comp.description}</p>
                         <p className="text-xs text-primary font-mono">{comp.example}</p>
                       </div>
                     ))}
@@ -693,7 +693,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <div className="bg-primary/5 rounded-lg p-4">
                     <ol className="space-y-2">
                       {Object.entries(currentStepData.content.howItWorks).map(([key, value], idx) => (
-                        <li key={key} className="text-sm text-muted-foreground flex gap-2">
+                        <li key={key} className="text-sm text-white/50 flex gap-2">
                           <span className="font-bold text-primary">{idx + 1}.</span>
                           <span>{value}</span>
                         </li>
@@ -712,10 +712,10 @@ const LiquidityPoolBasicsTutorial = () => {
                     <p className="text-2xl font-mono font-bold text-primary mb-2 whitespace-nowrap">
                       {currentStepData.content.constantProduct.formula}
                     </p>
-                    <p className="text-sm text-muted-foreground mb-2">
+                    <p className="text-sm text-white/50 mb-2">
                       {currentStepData.content.constantProduct.meaning}
                     </p>
-                    <p className="text-xs text-muted-foreground font-mono">
+                    <p className="text-xs text-white/50 font-mono">
                       Example: {currentStepData.content.constantProduct.example}
                     </p>
                   </div>
@@ -725,22 +725,22 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Price Calculation Examples</h3>
                   <div className="space-y-3">
                     {currentStepData.content.priceCalculation.map((calc, idx) => (
-                      <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-3">{calc.scenario}</h4>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
                           <div>
-                            <span className="text-muted-foreground">ETH:</span>
+                            <span className="text-white/50">ETH:</span>
                             <span className="ml-2 font-mono text-foreground">{calc.ethAmount}</span>
                           </div>
                           <div>
-                            <span className="text-muted-foreground">USDC:</span>
+                            <span className="text-white/50">USDC:</span>
                             <span className="ml-2 font-mono text-foreground">{calc.usdcAmount}</span>
                           </div>
                           <div className="col-span-2">
-                            <span className="text-muted-foreground">ETH Price:</span>
+                            <span className="text-white/50">ETH Price:</span>
                             <span className="ml-2 font-bold text-primary">{calc.ethPrice}</span>
                           </div>
-                          <div className="col-span-2 text-xs text-muted-foreground italic mt-2">
+                          <div className="col-span-2 text-xs text-white/50 italic mt-2">
                             {calc.calculation}
                           </div>
                         </div>
@@ -780,16 +780,16 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Real Examples</h3>
                   <div className="space-y-3">
                     {currentStepData.content.examples.map((example, idx) => (
-                      <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-3 flex items-center gap-2">
                           {example.scenario}
                         </h4>
                         <div className="space-y-2 text-sm">
-                          <p><span className="text-muted-foreground">Initial:</span> <span className="ml-2">{example.initial}</span></p>
-                          <p><span className="text-muted-foreground">Final:</span> <span className="ml-2">{example.final}</span></p>
-                          <p><span className="text-muted-foreground">If You Just Held:</span> <span className="ml-2 font-bold">{example.holdValue}</span></p>
-                          <p><span className="text-muted-foreground">Pool Value:</span> <span className="ml-2">{example.poolValue}</span></p>
-                          <p className="font-medium pt-2 border-t border-border/50">{example.result}</p>
+                          <p><span className="text-white/50">Initial:</span> <span className="ml-2">{example.initial}</span></p>
+                          <p><span className="text-white/50">Final:</span> <span className="ml-2">{example.final}</span></p>
+                          <p><span className="text-white/50">If You Just Held:</span> <span className="ml-2 font-bold">{example.holdValue}</span></p>
+                          <p><span className="text-white/50">Pool Value:</span> <span className="ml-2">{example.poolValue}</span></p>
+                          <p className="font-medium pt-2 border-t border-white/8">{example.result}</p>
                         </div>
                       </div>
                     ))}
@@ -798,11 +798,11 @@ const LiquidityPoolBasicsTutorial = () => {
 
                 <div className="space-y-3">
                   <h3 className="font-semibold text-foreground text-lg">IL by Price Change</h3>
-                  <div className="bg-muted/30 rounded-lg p-4">
+                  <div className="bg-white/5 rounded-lg p-4">
                     <div className="space-y-2">
                       {currentStepData.content.ilByPriceChange.map((row, idx) => (
                         <div key={idx} className="flex justify-between items-center text-sm">
-                          <span className="text-muted-foreground">{row.priceChange}</span>
+                          <span className="text-white/50">{row.priceChange}</span>
                           <span className="font-mono text-destructive font-medium">{row.ilPercent} loss</span>
                         </div>
                       ))}
@@ -814,7 +814,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">How to Mitigate IL</h3>
                   <ul className="space-y-2">
                     {currentStepData.content.mitigation.map((tip, idx) => (
-                      <li key={idx} className="text-sm text-muted-foreground flex gap-2">
+                      <li key={idx} className="text-sm text-white/50 flex gap-2">
                         <CheckCircle className="h-4 w-4 text-primary shrink-0 mt-0.5" />
                         <span>{tip}</span>
                       </li>
@@ -830,19 +830,19 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Pool Categories</h3>
                   <div className="space-y-3">
                     {currentStepData.content.poolCategories.map((cat, idx) => (
-                      <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                         <div className="flex items-center justify-between mb-3">
                           <h4 className="font-medium text-foreground">{cat.category}</h4>
                           <Badge variant="outline">{cat.apyRange} APY</Badge>
                         </div>
                         <div className="space-y-2 text-sm">
-                          <p><span className="text-muted-foreground">Examples:</span> <span className="ml-2 font-mono">{cat.examples}</span></p>
-                          <p><span className="text-muted-foreground">IL Risk:</span> <span className="ml-2">{cat.ilRisk}</span></p>
-                          <p><span className="text-muted-foreground">Best For:</span> <span className="ml-2">{cat.bestFor}</span></p>
-                          <div className="pt-2 border-t border-border/50">
+                          <p><span className="text-white/50">Examples:</span> <span className="ml-2 font-mono">{cat.examples}</span></p>
+                          <p><span className="text-white/50">IL Risk:</span> <span className="ml-2">{cat.ilRisk}</span></p>
+                          <p><span className="text-white/50">Best For:</span> <span className="ml-2">{cat.bestFor}</span></p>
+                          <div className="pt-2 border-t border-white/8">
                             <ul className="space-y-1">
                               {cat.considerations.map((point, pidx) => (
-                                <li key={pidx} className="text-muted-foreground">• {point}</li>
+                                <li key={pidx} className="text-white/50">• {point}</li>
                               ))}
                             </ul>
                           </div>
@@ -856,14 +856,14 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Pool Evaluation Criteria</h3>
                   <div className="space-y-2">
                     {currentStepData.content.evaluationCriteria.map((crit, idx) => (
-                      <div key={idx} className="bg-muted/30 rounded-lg p-3">
+                      <div key={idx} className="bg-white/5 rounded-lg p-3">
                         <div className="flex items-center justify-between mb-2">
                           <h4 className="font-medium text-foreground text-sm">{crit.criterion}</h4>
                           <Badge variant={crit.importance === "High" ? "default" : "secondary"} className="text-xs">
                             {crit.importance}
                           </Badge>
                         </div>
-                        <p className="text-xs text-muted-foreground mb-1">✅ {crit.whatToLookFor}</p>
+                        <p className="text-xs text-white/50 mb-1">✅ {crit.whatToLookFor}</p>
                         <p className="text-xs text-destructive">🚩 {crit.redFlag}</p>
                       </div>
                     ))}
@@ -878,7 +878,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Prerequisites</h3>
                   <ul className="space-y-2">
                     {currentStepData.content.prerequisites.map((prereq, idx) => (
-                      <li key={idx} className="text-sm text-muted-foreground flex gap-2">
+                      <li key={idx} className="text-sm text-white/50 flex gap-2">
                         <CheckCircle className="h-4 w-4 text-primary shrink-0 mt-0.5" />
                         <span>{prereq}</span>
                       </li>
@@ -888,7 +888,7 @@ const LiquidityPoolBasicsTutorial = () => {
 
                 <div className="space-y-4">
                   {currentStepData.content.steps.map((step, idx) => (
-                    <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                    <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                       <div className="flex items-start gap-3">
                         <div className="bg-primary text-primary-foreground rounded-full w-8 h-8 flex items-center justify-center font-bold shrink-0">
                           {step.step}
@@ -898,13 +898,13 @@ const LiquidityPoolBasicsTutorial = () => {
                             <h4 className="font-medium text-foreground">{step.action}</h4>
                             <Badge variant="outline" className="text-xs">{step.time}</Badge>
                           </div>
-                          <p className="text-sm text-muted-foreground">{step.details}</p>
+                          <p className="text-sm text-white/50">{step.details}</p>
                           
                           {step.feeTiers && (
-                            <div className="bg-muted/30 rounded p-2 mt-2">
+                            <div className="bg-white/5 rounded p-2 mt-2">
                               <p className="text-xs font-medium text-foreground mb-1">Fee Tiers:</p>
                               {step.feeTiers.map((tier, tidx) => (
-                                <p key={tidx} className="text-xs text-muted-foreground">
+                                <p key={tidx} className="text-xs text-white/50">
                                   • {tier.tier}: {tier.bestFor}
                                 </p>
                               ))}
@@ -914,9 +914,9 @@ const LiquidityPoolBasicsTutorial = () => {
                           {step.options && (
                             <div className="space-y-2 mt-2">
                               {step.options.map((opt, oidx) => (
-                                <div key={oidx} className="bg-muted/30 rounded p-2">
+                                <div key={oidx} className="bg-white/5 rounded p-2">
                                   <p className="text-xs font-medium text-foreground">{opt.option}</p>
-                                  <p className="text-xs text-muted-foreground">{opt.description}</p>
+                                  <p className="text-xs text-white/50">{opt.description}</p>
                                   <p className="text-xs text-primary">✅ {opt.pros}</p>
                                   <p className="text-xs text-destructive">⚠️ {opt.cons}</p>
                                 </div>
@@ -936,7 +936,7 @@ const LiquidityPoolBasicsTutorial = () => {
                           )}
 
                           {step.gasNote && (
-                            <p className="text-xs text-muted-foreground mt-2">⚡ {step.gasNote}</p>
+                            <p className="text-xs text-white/50 mt-2">⚡ {step.gasNote}</p>
                           )}
 
                           {step.tip && (
@@ -948,14 +948,14 @@ const LiquidityPoolBasicsTutorial = () => {
                               <p className="text-xs font-medium text-foreground mb-1">What happens:</p>
                               <ul className="space-y-1">
                                 {step.whatHappens.map((item, widx) => (
-                                  <li key={widx} className="text-xs text-muted-foreground">• {item}</li>
+                                  <li key={widx} className="text-xs text-white/50">• {item}</li>
                                 ))}
                               </ul>
                             </div>
                           )}
 
                           {step.tracking && (
-                            <p className="text-xs text-muted-foreground mt-2">📊 {step.tracking}</p>
+                            <p className="text-xs text-white/50 mt-2">📊 {step.tracking}</p>
                           )}
                         </div>
                       </div>
@@ -979,13 +979,13 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Monitoring Metrics</h3>
                   <div className="space-y-3">
                     {currentStepData.content.monitoringMetrics.map((metric, idx) => (
-                      <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                         <div className="flex items-center justify-between mb-2">
                           <h4 className="font-medium text-foreground">{metric.metric}</h4>
                           <Badge variant="outline" className="text-xs">{metric.frequency}</Badge>
                         </div>
                         <p className="text-sm text-primary mb-1">✅ {metric.goodSign}</p>
-                        <p className="text-sm text-muted-foreground">→ {metric.action}</p>
+                        <p className="text-sm text-white/50">→ {metric.action}</p>
                       </div>
                     ))}
                   </div>
@@ -995,7 +995,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">When to Exit</h3>
                   <ul className="space-y-2">
                     {currentStepData.content.whenToExit.map((reason, idx) => (
-                      <li key={idx} className="text-sm text-muted-foreground flex gap-2">
+                      <li key={idx} className="text-sm text-white/50 flex gap-2">
                         <AlertTriangle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
                         <span>{reason}</span>
                       </li>
@@ -1007,9 +1007,9 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Exit Process</h3>
                   <div className="space-y-2">
                     {currentStepData.content.exitProcess.map((step, idx) => (
-                      <div key={idx} className="bg-muted/30 rounded-lg p-3">
+                      <div key={idx} className="bg-white/5 rounded-lg p-3">
                         <h4 className="font-medium text-foreground text-sm mb-1">{step.step}</h4>
-                        <p className="text-xs text-muted-foreground">{step.details}</p>
+                        <p className="text-xs text-white/50">{step.details}</p>
                       </div>
                     ))}
                   </div>
@@ -1029,15 +1029,15 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Advanced Strategies</h3>
                   <div className="space-y-3">
                     {currentStepData.content.strategies.map((strategy, idx) => (
-                      <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-2">{strategy.strategy}</h4>
-                        <p className="text-sm text-muted-foreground mb-3">{strategy.description}</p>
+                        <p className="text-sm text-white/50 mb-3">{strategy.description}</p>
                         <div className="space-y-1 text-sm">
-                          <p><span className="text-muted-foreground">Example:</span> <span className="ml-2">{strategy.example}</span></p>
+                          <p><span className="text-white/50">Example:</span> <span className="ml-2">{strategy.example}</span></p>
                           <p><span className="text-primary">APY Boost:</span> <span className="ml-2 font-medium">{strategy.apyBoost}</span></p>
                           <p><span className="text-destructive">Risk:</span> <span className="ml-2">{strategy.risk}</span></p>
                           {strategy.platforms && (
-                            <p><span className="text-muted-foreground">Platforms:</span> <span className="ml-2">{strategy.platforms}</span></p>
+                            <p><span className="text-white/50">Platforms:</span> <span className="ml-2">{strategy.platforms}</span></p>
                           )}
                           {strategy.bestFor && (
                             <p><span className="text-accent">Best For:</span> <span className="ml-2">{strategy.bestFor}</span></p>
@@ -1046,7 +1046,7 @@ const LiquidityPoolBasicsTutorial = () => {
                             <p><span className="text-primary">Benefit:</span> <span className="ml-2">{strategy.benefit}</span></p>
                           )}
                           {strategy.cost && (
-                            <p><span className="text-muted-foreground">Cost:</span> <span className="ml-2">{strategy.cost}</span></p>
+                            <p><span className="text-white/50">Cost:</span> <span className="ml-2">{strategy.cost}</span></p>
                           )}
                         </div>
                       </div>
@@ -1076,9 +1076,9 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Common Mistakes</h3>
                   <div className="space-y-3">
                     {currentStepData.content.commonMistakes.map((mistake, idx) => (
-                      <div key={idx} className="bg-card border border-border/50 rounded-lg p-4">
+                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-destructive mb-2">❌ {mistake.mistake}</h4>
-                        <p className="text-sm text-muted-foreground mb-2">
+                        <p className="text-sm text-white/50 mb-2">
                           <strong>Consequence:</strong> {mistake.consequence}
                         </p>
                         <p className="text-sm text-primary">
@@ -1093,9 +1093,9 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Best Practices</h3>
                   <div className="space-y-2">
                     {currentStepData.content.bestPractices.map((practice, idx) => (
-                      <div key={idx} className="bg-muted/30 rounded-lg p-3">
+                      <div key={idx} className="bg-white/5 rounded-lg p-3">
                         <h4 className="font-medium text-foreground text-sm mb-1">✅ {practice.practice}</h4>
-                        <p className="text-xs text-muted-foreground mb-1">{practice.details}</p>
+                        <p className="text-xs text-white/50 mb-1">{practice.details}</p>
                         {practice.timeframe && (
                           <Badge variant="outline" className="text-xs">{practice.timeframe}</Badge>
                         )}
@@ -1131,7 +1131,7 @@ const LiquidityPoolBasicsTutorial = () => {
             )}
 
             {/* Navigation */}
-            <div className="flex flex-col sm:flex-row gap-3 justify-between items-stretch sm:items-center pt-6 border-t border-border/50">
+            <div className="flex flex-col sm:flex-row gap-3 justify-between items-stretch sm:items-center pt-6 border-t border-white/8">
               <Button
                 variant="outline"
                 onClick={handlePrevious}

--- a/src/pages/NftDefiTutorial.tsx
+++ b/src/pages/NftDefiTutorial.tsx
@@ -43,34 +43,34 @@ const NftDefiTutorial = () => {
                 <Image className="w-5 h-5 text-primary" />
                 <h4 className="font-semibold">Non-Fungible</h4>
               </div>
-              <p className="text-sm text-muted-foreground">Each NFT is unique and cannot be replaced by another identical item</p>
+              <p className="text-sm text-white/50">Each NFT is unique and cannot be replaced by another identical item</p>
             </Card>
             <Card className="p-4 border-accent/20">
               <div className="flex items-center gap-3 mb-2">
                 <Lock className="w-5 h-5 text-accent" />
                 <h4 className="font-semibold">Blockchain Verified</h4>
               </div>
-              <p className="text-sm text-muted-foreground">Ownership and authenticity are verified on the blockchain</p>
+              <p className="text-sm text-white/50">Ownership and authenticity are verified on the blockchain</p>
             </Card>
             <Card className="p-4 border-awareness/20">
               <div className="flex items-center gap-3 mb-2">
                 <Zap className="w-5 h-5 text-awareness" />
                 <h4 className="font-semibold">Programmable</h4>
               </div>
-              <p className="text-sm text-muted-foreground">Smart contracts can add utility and functionality</p>
+              <p className="text-sm text-white/50">Smart contracts can add utility and functionality</p>
             </Card>
           </div>
           
           <div className="border rounded p-4">
             <h4 className="font-semibold mb-2">Common NFT Standards</h4>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div className="p-2 bg-muted rounded">
+              <div className="p-2 bg-white/5 rounded">
                 <h5 className="font-medium text-sm">ERC-721</h5>
-                <p className="text-xs text-muted-foreground">Individual unique tokens</p>
+                <p className="text-xs text-white/50">Individual unique tokens</p>
               </div>
-              <div className="p-2 bg-muted rounded">
+              <div className="p-2 bg-white/5 rounded">
                 <h5 className="font-medium text-sm">ERC-1155</h5>
-                <p className="text-xs text-muted-foreground">Semi-fungible tokens</p>
+                <p className="text-xs text-white/50">Semi-fungible tokens</p>
               </div>
             </div>
           </div>
@@ -86,7 +86,7 @@ const NftDefiTutorial = () => {
           
           <Card className="p-4 bg-accent/10 border-accent">
             <h4 className="font-semibold text-foreground mb-2">How It Works</h4>
-            <ol className="text-sm text-muted-foreground space-y-1">
+            <ol className="text-sm text-white/50 space-y-1">
               <li>1. Deposit your NFT as collateral</li>
               <li>2. Receive a loan in cryptocurrency (usually ETH or stablecoins)</li>
               <li>3. Pay interest over the loan period</li>
@@ -140,7 +140,7 @@ const NftDefiTutorial = () => {
                 <Lock className="w-5 h-5 text-success" />
                 <h4 className="font-semibold">NFT Staking</h4>
               </div>
-              <p className="text-sm text-muted-foreground mb-2">Lock your NFTs to earn token rewards</p>
+              <p className="text-sm text-white/50 mb-2">Lock your NFTs to earn token rewards</p>
               <ul className="text-xs space-y-1">
                 <li>• Keep ownership while earning passive income</li>
                 <li>• Rewards often paid in project tokens</li>
@@ -153,7 +153,7 @@ const NftDefiTutorial = () => {
                 <Coins className="w-5 h-5 text-accent" />
                 <h4 className="font-semibold">Liquidity Mining</h4>
               </div>
-              <p className="text-sm text-muted-foreground mb-2">Provide NFT liquidity to earn trading fees</p>
+              <p className="text-sm text-white/50 mb-2">Provide NFT liquidity to earn trading fees</p>
               <ul className="text-xs space-y-1">
                 <li>• Deposit NFTs into liquidity pools</li>
                 <li>• Earn from trading fees and incentives</li>
@@ -166,7 +166,7 @@ const NftDefiTutorial = () => {
                 <TrendingUp className="w-5 h-5 text-primary" />
                 <h4 className="font-semibold">Fractionalized Ownership</h4>
               </div>
-              <p className="text-sm text-muted-foreground mb-2">Own fractions of expensive NFTs</p>
+              <p className="text-sm text-white/50 mb-2">Own fractions of expensive NFTs</p>
               <ul className="text-xs space-y-1">
                 <li>• Split expensive NFTs into tradeable tokens</li>
                 <li>• Lower barrier to entry</li>
@@ -177,7 +177,7 @@ const NftDefiTutorial = () => {
           
           <Card className="p-4 bg-awareness/10 border-awareness">
             <h4 className="font-semibold text-foreground mb-2">⚠️ Yield Farming Risks</h4>
-            <ul className="text-sm text-muted-foreground space-y-1">
+            <ul className="text-sm text-white/50 space-y-1">
               <li>• Smart contract vulnerabilities</li>
               <li>• Token price volatility</li>
               <li>• Liquidity risks when unstaking</li>
@@ -201,21 +201,21 @@ const NftDefiTutorial = () => {
                 <div className="flex justify-between items-center p-2 border rounded">
                   <div>
                     <span className="font-medium">OpenSea</span>
-                    <p className="text-xs text-muted-foreground">Largest NFT marketplace</p>
+                    <p className="text-xs text-white/50">Largest NFT marketplace</p>
                   </div>
                   <Badge variant="outline">2.5% fee</Badge>
                 </div>
                 <div className="flex justify-between items-center p-2 border rounded">
                   <div>
                     <span className="font-medium">LooksRare</span>
-                    <p className="text-xs text-muted-foreground">Rewards for trading</p>
+                    <p className="text-xs text-white/50">Rewards for trading</p>
                   </div>
                   <Badge variant="outline">2% fee</Badge>
                 </div>
                 <div className="flex justify-between items-center p-2 border rounded">
                   <div>
                     <span className="font-medium">X2Y2</span>
-                    <p className="text-xs text-muted-foreground">Lower fees</p>
+                    <p className="text-xs text-white/50">Lower fees</p>
                   </div>
                   <Badge variant="outline">0.5% fee</Badge>
                 </div>
@@ -227,19 +227,19 @@ const NftDefiTutorial = () => {
               <div className="space-y-3">
                 <div className="p-3 border rounded">
                   <h5 className="font-medium text-sm">Floor Sweeping</h5>
-                  <p className="text-xs text-muted-foreground">Buy multiple NFTs at floor price</p>
+                  <p className="text-xs text-white/50">Buy multiple NFTs at floor price</p>
                 </div>
                 <div className="p-3 border rounded">
                   <h5 className="font-medium text-sm">Trait Sniping</h5>
-                  <p className="text-xs text-muted-foreground">Target undervalued rare traits</p>
+                  <p className="text-xs text-white/50">Target undervalued rare traits</p>
                 </div>
                 <div className="p-3 border rounded">
                   <h5 className="font-medium text-sm">Flip Trading</h5>
-                  <p className="text-xs text-muted-foreground">Quick buy and sell for profit</p>
+                  <p className="text-xs text-white/50">Quick buy and sell for profit</p>
                 </div>
                 <div className="p-3 border rounded">
                   <h5 className="font-medium text-sm">Long-term Holding</h5>
-                  <p className="text-xs text-muted-foreground">Accumulate blue-chip collections</p>
+                  <p className="text-xs text-white/50">Accumulate blue-chip collections</p>
                 </div>
               </div>
             </Card>
@@ -270,15 +270,15 @@ const NftDefiTutorial = () => {
               <div className="space-y-2">
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">In-Game Assets</h5>
-                  <p className="text-xs text-muted-foreground">Weapons, characters, skins that you truly own</p>
+                  <p className="text-xs text-white/50">Weapons, characters, skins that you truly own</p>
                 </div>
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Play-to-Earn</h5>
-                  <p className="text-xs text-muted-foreground">Earn NFTs and tokens by playing games</p>
+                  <p className="text-xs text-white/50">Earn NFTs and tokens by playing games</p>
                 </div>
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Cross-Game Utility</h5>
-                  <p className="text-xs text-muted-foreground">Use NFTs across multiple games/platforms</p>
+                  <p className="text-xs text-white/50">Use NFTs across multiple games/platforms</p>
                 </div>
               </div>
             </Card>
@@ -288,15 +288,15 @@ const NftDefiTutorial = () => {
               <div className="space-y-2">
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Land Ownership</h5>
-                  <p className="text-xs text-muted-foreground">Own virtual plots in metaverse worlds</p>
+                  <p className="text-xs text-white/50">Own virtual plots in metaverse worlds</p>
                 </div>
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Development Rights</h5>
-                  <p className="text-xs text-muted-foreground">Build experiences on your land</p>
+                  <p className="text-xs text-white/50">Build experiences on your land</p>
                 </div>
                 <div className="p-2 border rounded">
                   <h5 className="font-medium text-sm">Rental Income</h5>
-                  <p className="text-xs text-muted-foreground">Lease land to other users/brands</p>
+                  <p className="text-xs text-white/50">Lease land to other users/brands</p>
                 </div>
               </div>
             </Card>
@@ -307,19 +307,19 @@ const NftDefiTutorial = () => {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Axie Infinity</h5>
-                <p className="text-xs text-muted-foreground">Pet battling game</p>
+                <p className="text-xs text-white/50">Pet battling game</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">The Sandbox</h5>
-                <p className="text-xs text-muted-foreground">Voxel metaverse</p>
+                <p className="text-xs text-white/50">Voxel metaverse</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Decentraland</h5>
-                <p className="text-xs text-muted-foreground">Virtual world platform</p>
+                <p className="text-xs text-white/50">Virtual world platform</p>
               </div>
               <div className="p-3 border rounded">
                 <h5 className="font-medium text-sm">Gods Unchained</h5>
-                <p className="text-xs text-muted-foreground">Trading card game</p>
+                <p className="text-xs text-white/50">Trading card game</p>
               </div>
             </div>
           </Card>
@@ -339,19 +339,19 @@ const NftDefiTutorial = () => {
               <div className="space-y-2">
                 <div className="p-2 border border-destructive/30 rounded">
                   <h5 className="font-medium text-sm text-destructive">Liquidity Risk</h5>
-                  <p className="text-xs text-muted-foreground">NFTs can become illiquid quickly</p>
+                  <p className="text-xs text-white/50">NFTs can become illiquid quickly</p>
                 </div>
                 <div className="p-2 border border-destructive/30 rounded">
                   <h5 className="font-medium text-sm text-destructive">Volatility Risk</h5>
-                  <p className="text-xs text-muted-foreground">Prices can swing dramatically</p>
+                  <p className="text-xs text-white/50">Prices can swing dramatically</p>
                 </div>
                 <div className="p-2 border border-destructive/30 rounded">
                   <h5 className="font-medium text-sm text-destructive">Technical Risk</h5>
-                  <p className="text-xs text-muted-foreground">Smart contract bugs and exploits</p>
+                  <p className="text-xs text-white/50">Smart contract bugs and exploits</p>
                 </div>
                 <div className="p-2 border border-destructive/30 rounded">
                   <h5 className="font-medium text-sm text-destructive">Regulatory Risk</h5>
-                  <p className="text-xs text-muted-foreground">Uncertain legal framework</p>
+                  <p className="text-xs text-white/50">Uncertain legal framework</p>
                 </div>
               </div>
             </Card>
@@ -438,7 +438,7 @@ const NftDefiTutorial = () => {
         <div className="flex items-center justify-between mb-4">
           <div>
             <h1 className="text-3xl font-bold">NFT & DeFi Integration</h1>
-            <p className="text-muted-foreground">Discover how NFTs and DeFi protocols work together</p>
+            <p className="text-white/50">Discover how NFTs and DeFi protocols work together</p>
           </div>
           <Badge variant="secondary">Medium Priority</Badge>
         </div>
@@ -486,7 +486,7 @@ const NftDefiTutorial = () => {
                 <div
                   key={index}
                   className={`p-3 rounded cursor-pointer transition-colors ${
-                    currentStep === index ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+                    currentStep === index ? 'bg-primary text-primary-foreground' : 'hover:bg-white/5'
                   }`}
                   onClick={() => handleStepChange(index)}
                 >

--- a/src/pages/PortfolioRebalancingTutorial.tsx
+++ b/src/pages/PortfolioRebalancingTutorial.tsx
@@ -588,7 +588,7 @@ const PortfolioRebalancingTutorial = () => {
         {/* Back Button */}
         <div className="mb-6">
           <Link to="/tutorials?tab=practical">
-            <Button variant="ghost" className="gap-2 hover:bg-muted">
+            <Button variant="ghost" className="gap-2 hover:bg-white/5">
               <ArrowLeft className="w-4 h-4" />
               Back to Practical DeFi Actions
             </Button>
@@ -603,7 +603,7 @@ const PortfolioRebalancingTutorial = () => {
             </div>
             <div>
               <h1 className="text-3xl font-bold">Portfolio Rebalancing Techniques</h1>
-              <p className="text-muted-foreground">Master systematic portfolio optimization strategies</p>
+              <p className="text-white/50">Master systematic portfolio optimization strategies</p>
             </div>
           </div>
 
@@ -694,7 +694,7 @@ const PortfolioRebalancingTutorial = () => {
             </CardHeader>
 
             <CardContent className="space-y-4 md:space-y-6 p-3 md:p-6">
-              <p className="text-muted-foreground text-sm md:text-base">{currentStepData.content.overview}</p>
+              <p className="text-white/50 text-sm md:text-base">{currentStepData.content.overview}</p>
 
               {/* Render Step-Specific Content */}
               {currentStep === 1 && currentStepData.content.whyRebalance && (
@@ -714,7 +714,7 @@ const PortfolioRebalancingTutorial = () => {
                         </CardHeader>
                         <CardContent className="space-y-2 text-xs md:text-sm p-3 md:p-6 pt-0">
                           <p>{trigger.description}</p>
-                          <p className="text-xs text-muted-foreground">Best for: {trigger.bestFor}</p>
+                          <p className="text-xs text-white/50">Best for: {trigger.bestFor}</p>
                         </CardContent>
                       </Card>
                     ))}
@@ -731,7 +731,7 @@ const PortfolioRebalancingTutorial = () => {
                               {portfolio.riskLevel}
                             </Badge>
                           </div>
-                          <p className="text-xs md:text-sm text-muted-foreground mb-2">{portfolio.allocation}</p>
+                          <p className="text-xs md:text-sm text-white/50 mb-2">{portfolio.allocation}</p>
                           <div className="flex flex-wrap gap-2 md:gap-4 text-xs">
                             <span>Frequency: {portfolio.rebalanceFreq}</span>
                             <span>Target: {portfolio.targetAPY}</span>
@@ -756,20 +756,20 @@ const PortfolioRebalancingTutorial = () => {
                         <div className="grid md:grid-cols-2 gap-2 mt-2">
                           <div>
                             <p className="font-semibold text-xs mb-1">Advantages:</p>
-                            <ul className="text-xs space-y-1 text-muted-foreground">
+                            <ul className="text-xs space-y-1 text-white/50">
                               {strategy.advantages.map((adv, i) => <li key={i}>• {adv}</li>)}
                             </ul>
                           </div>
                           <div>
                             <p className="font-semibold text-xs mb-1">Disadvantages:</p>
-                            <ul className="text-xs space-y-1 text-muted-foreground">
+                            <ul className="text-xs space-y-1 text-white/50">
                               {strategy.disadvantages.map((dis, i) => <li key={i}>• {dis}</li>)}
                             </ul>
                           </div>
                         </div>
                         <div className="flex gap-2 text-xs pt-2 border-t">
                           <Badge variant="outline">Gas: {strategy.gasEfficiency}</Badge>
-                          <span className="text-muted-foreground">{strategy.bestMarkets}</span>
+                          <span className="text-white/50">{strategy.bestMarkets}</span>
                         </div>
                       </CardContent>
                     </Card>
@@ -790,7 +790,7 @@ const PortfolioRebalancingTutorial = () => {
                         <CardDescription>{phase.description}</CardDescription>
                       </CardHeader>
                       <CardContent className="space-y-2 text-sm">
-                        <div className="flex gap-2 text-xs text-muted-foreground">
+                        <div className="flex gap-2 text-xs text-white/50">
                           <Clock className="h-3 w-3" />
                           {phase.timeRequired}
                         </div>
@@ -816,7 +816,7 @@ const PortfolioRebalancingTutorial = () => {
                         </CardTitle>
                       </CardHeader>
                       <CardContent className="space-y-2 text-sm">
-                        <p className="text-xs text-muted-foreground">Causes: {issue.causes.join(", ")}</p>
+                        <p className="text-xs text-white/50">Causes: {issue.causes.join(", ")}</p>
                         <div>
                           <p className="text-xs font-semibold mb-1">Solutions:</p>
                           <ul className="space-y-1 text-xs">
@@ -888,7 +888,7 @@ const PortfolioRebalancingTutorial = () => {
                       <CardContent className="space-y-1 text-sm">
                         <p className="text-xs"><strong>Calculation:</strong> {metric.calculation}</p>
                         <p className="text-xs"><strong>Target:</strong> {metric.target}</p>
-                        <p className="text-xs text-muted-foreground">{metric.interpretation}</p>
+                        <p className="text-xs text-white/50">{metric.interpretation}</p>
                       </CardContent>
                     </Card>
                   ))}
@@ -902,7 +902,7 @@ const PortfolioRebalancingTutorial = () => {
                         </CardHeader>
                         <CardContent className="text-xs space-y-1">
                           <p>{benchmark.description}</p>
-                          <p className="text-muted-foreground">{benchmark.useCase}</p>
+                          <p className="text-white/50">{benchmark.useCase}</p>
                         </CardContent>
                       </Card>
                     ))}

--- a/src/pages/PortfolioTrackingTutorial.tsx
+++ b/src/pages/PortfolioTrackingTutorial.tsx
@@ -67,7 +67,7 @@ const PortfolioTrackingTutorial = () => {
                   Track Performance
                 </CardTitle>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
+              <CardContent className="text-sm text-white/50">
                 Monitor returns across protocols, identify winning strategies, and cut losing positions early.
               </CardContent>
             </Card>
@@ -79,7 +79,7 @@ const PortfolioTrackingTutorial = () => {
                   Risk Management
                 </CardTitle>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
+              <CardContent className="text-sm text-white/50">
                 Spot concentration risks, monitor liquidation levels, and maintain balanced exposure.
               </CardContent>
             </Card>
@@ -91,7 +91,7 @@ const PortfolioTrackingTutorial = () => {
                   Tax Reporting
                 </CardTitle>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
+              <CardContent className="text-sm text-white/50">
                 Accurate transaction history makes tax time painless and ensures compliance.
               </CardContent>
             </Card>
@@ -103,7 +103,7 @@ const PortfolioTrackingTutorial = () => {
                   Optimize Allocation
                 </CardTitle>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
+              <CardContent className="text-sm text-white/50">
                 See where capital is working best and rebalance to maximize returns.
               </CardContent>
             </Card>
@@ -263,7 +263,7 @@ const PortfolioTrackingTutorial = () => {
             </CardHeader>
             <CardContent className="space-y-2 text-sm">
               <p>Use clear wallet labels to track strategy:</p>
-              <ul className="space-y-1 ml-4 text-muted-foreground">
+              <ul className="space-y-1 ml-4 text-white/50">
                 <li>• "Conservative Stables": Low-risk stable farming</li>
                 <li>• "High Yield Farming": Aggressive strategies</li>
                 <li>• "Long-term Holdings": Buy and hold positions</li>
@@ -278,7 +278,7 @@ const PortfolioTrackingTutorial = () => {
             </CardHeader>
             <CardContent className="space-y-2 text-sm">
               <p>Most trackers let you set notifications for:</p>
-              <ul className="space-y-1 ml-4 text-muted-foreground">
+              <ul className="space-y-1 ml-4 text-white/50">
                 <li>• Large price movements (±10%)</li>
                 <li>• Liquidation warnings</li>
                 <li>• Yield rate changes</li>
@@ -295,7 +295,7 @@ const PortfolioTrackingTutorial = () => {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <div>
                   <p className="font-semibold text-xs mb-1">Essential Metrics:</p>
-                  <ul className="space-y-1 text-xs text-muted-foreground">
+                  <ul className="space-y-1 text-xs text-white/50">
                     <li>• Total portfolio value (USD)</li>
                     <li>• 24h change %</li>
                     <li>• Asset allocation by chain</li>
@@ -304,7 +304,7 @@ const PortfolioTrackingTutorial = () => {
                 </div>
                 <div>
                   <p className="font-semibold text-xs mb-1">Advanced Metrics:</p>
-                  <ul className="space-y-1 text-xs text-muted-foreground">
+                  <ul className="space-y-1 text-xs text-white/50">
                     <li>• Realized vs unrealized gains</li>
                     <li>• Average entry prices</li>
                     <li>• Yield generated per protocol</li>
@@ -339,7 +339,7 @@ const PortfolioTrackingTutorial = () => {
                 </CardTitle>
               </CardHeader>
               <CardContent className="text-sm space-y-2">
-                <ul className="space-y-1 ml-4 text-muted-foreground">
+                <ul className="space-y-1 ml-4 text-white/50">
                   <li>✓ Check total portfolio value</li>
                   <li>✓ Review overnight performance</li>
                   <li>✓ Scan for any alerts or warnings</li>
@@ -356,7 +356,7 @@ const PortfolioTrackingTutorial = () => {
                 </CardTitle>
               </CardHeader>
               <CardContent className="text-sm space-y-2">
-                <ul className="space-y-1 ml-4 text-muted-foreground">
+                <ul className="space-y-1 ml-4 text-white/50">
                   <li>✓ Review day's performance by protocol</li>
                   <li>✓ Check for yield rate changes</li>
                   <li>✓ Note any positions that need attention</li>
@@ -373,7 +373,7 @@ const PortfolioTrackingTutorial = () => {
                 </CardTitle>
               </CardHeader>
               <CardContent className="text-sm space-y-2">
-                <ul className="space-y-1 ml-4 text-muted-foreground">
+                <ul className="space-y-1 ml-4 text-white/50">
                   <li>✓ Compare performance to last week</li>
                   <li>✓ Analyze winning and losing positions</li>
                   <li>✓ Review allocation vs targets</li>
@@ -408,7 +408,7 @@ const PortfolioTrackingTutorial = () => {
             </CardHeader>
             <CardContent className="space-y-2 text-sm">
               <p>Portfolio trackers can export your complete transaction history:</p>
-              <ul className="space-y-1 ml-4 text-muted-foreground">
+              <ul className="space-y-1 ml-4 text-white/50">
                 <li>• All swaps, deposits, and withdrawals</li>
                 <li>• Yield earned per protocol</li>
                 <li>• Realized gains/losses</li>
@@ -426,15 +426,15 @@ const PortfolioTrackingTutorial = () => {
               <div className="space-y-2">
                 <div>
                   <p className="font-semibold">CoinTracker</p>
-                  <p className="text-xs text-muted-foreground">Imports from most DeFi protocols, generates tax forms</p>
+                  <p className="text-xs text-white/50">Imports from most DeFi protocols, generates tax forms</p>
                 </div>
                 <div>
                   <p className="font-semibold">Koinly</p>
-                  <p className="text-xs text-muted-foreground">Great for complex DeFi transactions, supports 20+ countries</p>
+                  <p className="text-xs text-white/50">Great for complex DeFi transactions, supports 20+ countries</p>
                 </div>
                 <div>
                   <p className="font-semibold">TokenTax</p>
-                  <p className="text-xs text-muted-foreground">Specialized in DeFi yield farming and LP taxation</p>
+                  <p className="text-xs text-white/50">Specialized in DeFi yield farming and LP taxation</p>
                 </div>
               </div>
             </CardContent>
@@ -446,7 +446,7 @@ const PortfolioTrackingTutorial = () => {
             </CardHeader>
             <CardContent className="space-y-2 text-sm">
               <p>Compare your returns against:</p>
-              <ul className="space-y-1 ml-4 text-muted-foreground">
+              <ul className="space-y-1 ml-4 text-white/50">
                 <li>• DeFi Pulse Index (overall DeFi market)</li>
                 <li>• ETH performance (baseline)</li>
                 <li>• Top protocol yields</li>
@@ -549,7 +549,7 @@ const PortfolioTrackingTutorial = () => {
         {/* Back Button */}
         <div className="mb-6">
           <Link to="/tutorials?tab=practical">
-            <Button variant="ghost" className="gap-2 hover:bg-muted">
+            <Button variant="ghost" className="gap-2 hover:bg-white/5">
               <ArrowLeft className="w-4 h-4" />
               Back to Practical DeFi Actions
             </Button>
@@ -561,7 +561,7 @@ const PortfolioTrackingTutorial = () => {
           <div className="flex items-center justify-between mb-4">
             <div>
               <h1 className="text-3xl font-bold mb-2">Portfolio Tracking Setup</h1>
-              <p className="text-muted-foreground">Set up comprehensive DeFi portfolio tracking and monitoring</p>
+              <p className="text-white/50">Set up comprehensive DeFi portfolio tracking and monitoring</p>
             </div>
             <Badge variant="secondary">Medium Priority</Badge>
           </div>
@@ -606,7 +606,7 @@ const PortfolioTrackingTutorial = () => {
                 {isStepCompleted(step.id) ? (
                   <CheckCircle className="h-4 w-4 text-awareness flex-shrink-0" />
                 ) : (
-                  <Circle className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                  <Circle className="h-4 w-4 text-white/50 flex-shrink-0" />
                 )}
                 <span className="text-xs font-medium truncate">Step {step.id}</span>
               </CardContent>

--- a/src/pages/PredictionMarketsDeFi2025.tsx
+++ b/src/pages/PredictionMarketsDeFi2025.tsx
@@ -144,28 +144,28 @@ const PredictionMarketsDeFi2025 = () => {
                 </BlogParagraph>
 
                 <div className="grid md:grid-cols-2 gap-6 mb-6">
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Skin in the Game</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       When traders must stake real money on their predictions, biases become expensive. Wishful thinking, political loyalty, and overconfidence all cost money in prediction markets.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Information Aggregation</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Markets aggregate dispersed information. A trader with unique insight: perhaps industry knowledge or local information: can profit by trading on that insight, contributing it to the market price.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Continuous Updating</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Unlike polls conducted weekly or monthly, prediction markets update in real-time as new information emerges. Prices respond to news within minutes, not days.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Arbitrage Pressure</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       When prices deviate from reality, informed traders can profit by correcting the mispricing. This creates constant pressure toward accuracy that traditional forecasts lack.
@@ -173,33 +173,33 @@ const PredictionMarketsDeFi2025 = () => {
                   </div>
                 </div>
 
-                <div className="bg-muted/30 rounded-lg p-6 mb-6 overflow-x-auto">
+                <div className="bg-white/5 rounded-lg p-6 mb-6 overflow-x-auto">
                   <h3 className="text-xl font-semibold text-foreground mb-4">Traditional Forecasting vs. Prediction Markets</h3>
                   <table className="w-full text-sm">
                     <thead>
-                      <tr className="border-b border-border">
+                      <tr className="border-b border-white/8">
                         <th className="text-left py-3 text-foreground font-semibold">Aspect</th>
                         <th className="text-left py-3 text-foreground font-semibold">Polls/Pundits</th>
                         <th className="text-left py-3 text-foreground font-semibold">Prediction Markets</th>
                       </tr>
                     </thead>
                     <tbody className="text-foreground/80">
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Accountability</td>
                         <td className="py-3">Reputational only</td>
                         <td className="py-3">Financial stake</td>
                       </tr>
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Update Frequency</td>
                         <td className="py-3">Days/weeks</td>
                         <td className="py-3">Real-time</td>
                       </tr>
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Bias Correction</td>
                         <td className="py-3">Limited</td>
                         <td className="py-3">Profitable to correct</td>
                       </tr>
-                      <tr className="border-b border-border/50">
+                      <tr className="border-b border-white/8">
                         <td className="py-3">Information Sources</td>
                         <td className="py-3">Survey responses</td>
                         <td className="py-3">All available data</td>
@@ -220,28 +220,28 @@ const PredictionMarketsDeFi2025 = () => {
                 </BlogParagraph>
 
                 <div className="grid md:grid-cols-2 gap-6 mb-6">
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Crypto Markets</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Markets on ETF approvals, protocol upgrades, token prices, and regulatory decisions provide real-time probability assessments for crypto-specific events.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Economic Indicators</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Federal Reserve decisions, inflation readings, and employment data can all be traded before official announcements.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Sports & Entertainment</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Award shows, box office performance, and sporting events provide entertainment-focused prediction opportunities.
                     </p>
                   </div>
 
-                  <div className="bg-muted/30 rounded-lg p-5">
+                  <div className="bg-white/5 rounded-lg p-5">
                     <h3 className="text-lg font-semibold text-foreground mb-3">Science & Technology</h3>
                     <p className="text-foreground/80 text-sm leading-relaxed">
                       Markets on AI development timelines, scientific discoveries, and technology adoption rates help forecast innovation.

--- a/src/pages/ReadingDefiMetricsTutorial.tsx
+++ b/src/pages/ReadingDefiMetricsTutorial.tsx
@@ -832,7 +832,7 @@ const ReadingDefiMetricsTutorial = () => {
         {/* Back to Tutorials Button */}
         <div className="mb-6">
           <Link to="/tutorials">
-            <Button variant="ghost" className="gap-2 hover:bg-muted">
+            <Button variant="ghost" className="gap-2 hover:bg-white/5">
               <ArrowLeft className="h-4 w-4" />
               Back to Tutorials
             </Button>
@@ -847,7 +847,7 @@ const ReadingDefiMetricsTutorial = () => {
             </div>
             <div>
               <h1 className="text-3xl font-bold">Reading DeFi Metrics</h1>
-              <p className="text-muted-foreground">Master data-driven DeFi investment decisions</p>
+              <p className="text-white/50">Master data-driven DeFi investment decisions</p>
             </div>
           </div>
 
@@ -938,7 +938,7 @@ const ReadingDefiMetricsTutorial = () => {
             </CardHeader>
 
             <CardContent className="space-y-4 md:space-y-6 p-3 md:p-6">
-              <p className="text-muted-foreground text-sm md:text-base">{currentStepData.content.overview}</p>
+              <p className="text-white/50 text-sm md:text-base">{currentStepData.content.overview}</p>
 
               {/* Content implementation would go here */}
 

--- a/src/pages/RiskAssessmentTutorial.tsx
+++ b/src/pages/RiskAssessmentTutorial.tsx
@@ -49,21 +49,21 @@ const RiskAssessmentTutorial = () => {
                 <TrendingDown className="w-4 h-4 md:w-5 md:h-5 text-destructive flex-shrink-0" />
                 <h4 className="font-semibold text-sm md:text-base">Market Risk</h4>
               </div>
-              <p className="text-xs md:text-sm text-muted-foreground break-words">Price volatility, impermanent loss, liquidity risks</p>
+              <p className="text-xs md:text-sm text-white/50 break-words">Price volatility, impermanent loss, liquidity risks</p>
             </Card>
             <Card className="p-3 md:p-4 border-awareness/20 text-center sm:text-left">
               <div className="flex items-center gap-2 md:gap-3 mb-1.5 md:mb-2 justify-center sm:justify-start">
                 <Shield className="w-4 h-4 md:w-5 md:h-5 text-awareness flex-shrink-0" />
                 <h4 className="font-semibold text-sm md:text-base">Smart Contract Risk</h4>
               </div>
-              <p className="text-xs md:text-sm text-muted-foreground break-words">Code vulnerabilities, bugs, exploits</p>
+              <p className="text-xs md:text-sm text-white/50 break-words">Code vulnerabilities, bugs, exploits</p>
             </Card>
             <Card className="p-3 md:p-4 border-accent/20 text-center sm:text-left">
               <div className="flex items-center gap-2 md:gap-3 mb-1.5 md:mb-2 justify-center sm:justify-start">
                 <Users className="w-4 h-4 md:w-5 md:h-5 text-accent flex-shrink-0" />
                 <h4 className="font-semibold text-sm md:text-base">Counterparty Risk</h4>
               </div>
-              <p className="text-xs md:text-sm text-muted-foreground break-words">Protocol governance, admin keys, centralization</p>
+              <p className="text-xs md:text-sm text-white/50 break-words">Protocol governance, admin keys, centralization</p>
             </Card>
           </div>
         </div>
@@ -122,7 +122,7 @@ const RiskAssessmentTutorial = () => {
               "Test with small amounts first"
             ].map((item, index) => (
               <div key={index} className="flex items-center gap-2 p-2 md:p-2.5 border rounded text-center sm:text-left justify-center sm:justify-start">
-                <Circle className="w-3 h-3 md:w-4 md:h-4 text-muted-foreground flex-shrink-0" />
+                <Circle className="w-3 h-3 md:w-4 md:h-4 text-white/50 flex-shrink-0" />
                 <span className="text-xs md:text-sm break-words">{item}</span>
               </div>
             ))}
@@ -139,19 +139,19 @@ const RiskAssessmentTutorial = () => {
           <div className="grid gap-2.5 md:gap-4">
             <Card className="p-3 md:p-4 text-center sm:text-left">
               <h4 className="font-semibold mb-1.5 md:mb-2 text-sm md:text-base">Diversification</h4>
-              <p className="text-xs md:text-sm text-muted-foreground break-words">Spread investments across multiple protocols and asset types</p>
+              <p className="text-xs md:text-sm text-white/50 break-words">Spread investments across multiple protocols and asset types</p>
             </Card>
             <Card className="p-3 md:p-4 text-center sm:text-left">
               <h4 className="font-semibold mb-1.5 md:mb-2 text-sm md:text-base">Position Sizing</h4>
-              <p className="text-xs md:text-sm text-muted-foreground break-words">Never invest more than you can afford to lose</p>
+              <p className="text-xs md:text-sm text-white/50 break-words">Never invest more than you can afford to lose</p>
             </Card>
             <Card className="p-3 md:p-4 text-center sm:text-left">
               <h4 className="font-semibold mb-1.5 md:mb-2 text-sm md:text-base">Dollar-Cost Averaging</h4>
-              <p className="text-xs md:text-sm text-muted-foreground break-words">Enter positions gradually over time</p>
+              <p className="text-xs md:text-sm text-white/50 break-words">Enter positions gradually over time</p>
             </Card>
             <Card className="p-3 md:p-4 text-center sm:text-left">
               <h4 className="font-semibold mb-1.5 md:mb-2 text-sm md:text-base">Stop Losses</h4>
-              <p className="text-xs md:text-sm text-muted-foreground break-words">Set clear exit criteria for losing positions</p>
+              <p className="text-xs md:text-sm text-white/50 break-words">Set clear exit criteria for losing positions</p>
             </Card>
           </div>
         </div>
@@ -271,7 +271,7 @@ const RiskAssessmentTutorial = () => {
         {/* Back to Tutorials Button */}
         <div className="mb-6">
           <Link to="/tutorials?tab=practical">
-            <Button variant="ghost" className="gap-2 hover:bg-muted min-h-[44px]">
+            <Button variant="ghost" className="gap-2 hover:bg-white/5 min-h-[44px]">
               <ArrowLeft className="w-4 h-4" />
               <span className="hidden sm:inline">Back to Practical DeFi Actions</span>
               <span className="sm:hidden">Back</span>
@@ -283,7 +283,7 @@ const RiskAssessmentTutorial = () => {
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
             <div>
               <h1 className="text-2xl md:text-3xl font-bold">Risk Assessment in Action</h1>
-              <p className="text-sm md:text-base text-muted-foreground">Learn to evaluate and manage DeFi risks systematically</p>
+              <p className="text-sm md:text-base text-white/50">Learn to evaluate and manage DeFi risks systematically</p>
             </div>
             <Badge variant="secondary" className="w-fit mx-auto sm:mx-0 text-xs">Medium Priority</Badge>
           </div>
@@ -331,7 +331,7 @@ const RiskAssessmentTutorial = () => {
                   <div
                     key={index}
                     className={`p-2.5 md:p-3 rounded cursor-pointer transition-colors text-center sm:text-left ${
-                      currentStep === index ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+                      currentStep === index ? 'bg-primary text-primary-foreground' : 'hover:bg-white/5'
                     }`}
                     onClick={() => setCurrentStep(index)}
                   >

--- a/src/pages/SpottingScamsTutorial.tsx
+++ b/src/pages/SpottingScamsTutorial.tsx
@@ -613,7 +613,7 @@ const SpottingScamsTutorial = () => {
       case "Critical": return "text-destructive bg-destructive/10 border-destructive/50";
       case "High": return "text-destructive bg-destructive/10 border-destructive/30";
       case "Medium": return "text-accent bg-accent/10 border-accent/30";
-      default: return "text-muted-foreground bg-muted border-border";
+      default: return "text-white/50 bg-white/5 border-white/8";
     }
   };
 
@@ -640,7 +640,7 @@ const SpottingScamsTutorial = () => {
             </div>
             <div>
               <h1 className="text-3xl font-bold">Spotting DeFi Scams</h1>
-              <p className="text-muted-foreground">Essential security skills for safe DeFi navigation</p>
+              <p className="text-white/50">Essential security skills for safe DeFi navigation</p>
             </div>
           </div>
 
@@ -733,7 +733,7 @@ const SpottingScamsTutorial = () => {
             </CardHeader>
 
             <CardContent className="space-y-4 md:space-y-6 p-4 md:p-6">
-              <p className="text-muted-foreground text-sm md:text-base">{currentStepData.content.overview}</p>
+              <p className="text-white/50 text-sm md:text-base">{currentStepData.content.overview}</p>
 
               {/* Step 1: Common Scam Types */}
               {currentStep === 1 && (
@@ -774,7 +774,7 @@ const SpottingScamsTutorial = () => {
                           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-center sm:text-left">
                             <div className="min-w-0">
                               <p className="font-medium mb-0.5 text-xs md:text-sm">Scammer's goal:</p>
-                              <p className="text-muted-foreground break-words text-xs md:text-sm">{scam.goal}</p>
+                              <p className="text-white/50 break-words text-xs md:text-sm">{scam.goal}</p>
                             </div>
                             <div className="min-w-0">
                               <p className="font-medium mb-0.5 text-xs md:text-sm">Example:</p>
@@ -869,7 +869,7 @@ const SpottingScamsTutorial = () => {
                         <Card key={index} className="border-l-4 border-destructive/50">
                           <CardContent className="p-3 md:p-4 text-center sm:text-left">
                             <h4 className="font-medium mb-1 text-sm md:text-base text-destructive">{request.type}</h4>
-                            <p className="text-xs md:text-sm text-muted-foreground mb-2 break-words">{request.description}</p>
+                            <p className="text-xs md:text-sm text-white/50 mb-2 break-words">{request.description}</p>
                             <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-xs md:text-sm">
                               <div className="min-w-0">
                                 <div className="flex items-center gap-1 mb-0.5 justify-center sm:justify-start">
@@ -911,7 +911,7 @@ const SpottingScamsTutorial = () => {
                               </Badge>
                               <div className="flex-1 min-w-0">
                                 <h4 className="font-medium mb-1 text-sm md:text-base break-words">{analysis.step}</h4>
-                                <p className="text-xs md:text-sm text-muted-foreground mb-1.5 break-words">{analysis.what}</p>
+                                <p className="text-xs md:text-sm text-white/50 mb-1.5 break-words">{analysis.what}</p>
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs md:text-sm">
                                   <div className="min-w-0">
                                     <span className="font-medium text-destructive">⚠️ Red Flag: </span>
@@ -945,11 +945,11 @@ const SpottingScamsTutorial = () => {
                             <div className="space-y-2 text-xs md:text-sm">
                               <div className="min-w-0">
                                 <span className="font-medium">Scenario: </span>
-                                <span className="text-muted-foreground break-words">{tactic.scenario}</span>
+                                <span className="text-white/50 break-words">{tactic.scenario}</span>
                               </div>
                               <div className="min-w-0">
                                 <span className="font-medium">Approach: </span>
-                                <span className="text-muted-foreground break-words">{tactic.approach}</span>
+                                <span className="text-white/50 break-words">{tactic.approach}</span>
                               </div>
                               <div className="min-w-0">
                                 <span className="font-medium text-destructive">Goal: </span>
@@ -987,7 +987,7 @@ const SpottingScamsTutorial = () => {
                               </div>
                               <div className="min-w-0">
                                 <span className="font-medium text-success mb-1.5 block text-xs">Safety Tips:</span>
-                                <p className="text-muted-foreground break-words">{platform.safety}</p>
+                                <p className="text-white/50 break-words">{platform.safety}</p>
                               </div>
                             </div>
                           </CardContent>
@@ -1131,7 +1131,7 @@ const SpottingScamsTutorial = () => {
                               <h4 className="font-medium break-words text-sm md:text-base">{tool.tool}</h4>
                               <Badge variant="outline" className="w-fit text-[10px] md:text-xs break-all mx-auto sm:mx-0">{tool.url}</Badge>
                             </div>
-                            <p className="text-xs md:text-sm text-muted-foreground mb-1.5 md:mb-2 break-words">{tool.purpose}</p>
+                            <p className="text-xs md:text-sm text-white/50 mb-1.5 md:mb-2 break-words">{tool.purpose}</p>
                             <div className="flex items-start gap-1.5 text-xs md:text-sm text-primary justify-center sm:justify-start">
                               <ExternalLink className="h-2.5 w-2.5 md:h-3 md:w-3 flex-shrink-0 mt-0.5" />
                               <span className="break-words">Usage: {tool.usage}</span>

--- a/src/pages/VaultDepositTutorial.tsx
+++ b/src/pages/VaultDepositTutorial.tsx
@@ -47,7 +47,7 @@ const VaultDepositTutorial = () => {
 
       <div className="container max-w-3xl px-4 py-8 md:py-12 space-y-6 md:space-y-8">
         {/* Back Navigation */}
-        <Link to="/vault-access" className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors text-sm">
+        <Link to="/vault-access" className="inline-flex items-center gap-2 text-white/50 hover:text-foreground transition-colors text-sm">
           <ArrowLeft className="h-4 w-4" />
           Back to Vault Access
         </Link>
@@ -59,7 +59,7 @@ const VaultDepositTutorial = () => {
             Tutorial
           </Badge>
           <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight">How to Deposit into the 3EA Vault</h1>
-          <p className="text-base md:text-lg text-muted-foreground">
+          <p className="text-base md:text-lg text-white/50">
             A complete guide to depositing into our Enzyme vault and viewing your vault tokens in MetaMask.
           </p>
 
@@ -93,7 +93,7 @@ const VaultDepositTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               MetaMask is a browser extension wallet that lets you interact with Ethereum dApps like Enzyme Finance.
             </p>
             
@@ -142,7 +142,7 @@ const VaultDepositTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               You'll need ETH in your wallet to purchase the NFT and pay for gas fees on all transactions.
             </p>
             
@@ -165,7 +165,7 @@ const VaultDepositTutorial = () => {
               </div>
             </div>
 
-            <Alert variant="default" className="bg-muted/50">
+            <Alert variant="default" className="bg-white/5">
               <div className="flex gap-3">
                 <Shield className="h-4 w-4 shrink-0 mt-0.5" />
                 <p className="text-sm">
@@ -193,7 +193,7 @@ const VaultDepositTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               The 3EA Earth Access NFT is required to deposit into the vault. Without it, you won't be able to access the vault even if you connect your wallet.
             </p>
             
@@ -242,7 +242,7 @@ const VaultDepositTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               After purchasing the NFT, your wallet address needs to be whitelisted on the Enzyme vault. This is a manual process that can take up to 7 days.
             </p>
             
@@ -293,7 +293,7 @@ const VaultDepositTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               Navigate to our vault on Enzyme Finance and connect your MetaMask wallet.
             </p>
             
@@ -346,7 +346,7 @@ const VaultDepositTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               Once connected, you can deposit ETH into the vault to receive vault shares.
             </p>
             
@@ -377,7 +377,7 @@ const VaultDepositTutorial = () => {
               </div>
             </div>
 
-            <Alert variant="default" className="bg-muted/50">
+            <Alert variant="default" className="bg-white/5">
               <Shield className="h-4 w-4 shrink-0" />
               <AlertDescription className="text-sm">
                 <strong>Note:</strong> Once deposited, your funds are managed by the vault strategy. 
@@ -404,12 +404,12 @@ const VaultDepositTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               Your vault shares are ERC-20 tokens. To see them in MetaMask, you need to manually add the token.
             </p>
 
             {/* Token Address Box */}
-            <div className="bg-muted/50 rounded-lg p-3 md:p-4 space-y-2">
+            <div className="bg-white/5 rounded-lg p-3 md:p-4 space-y-2">
               <p className="text-xs md:text-sm font-medium">Vault Token Contract Address:</p>
               <div className="flex items-center gap-2">
                 <code className="flex-1 text-[10px] md:text-sm bg-background rounded px-2 md:px-3 py-2 overflow-x-auto break-all">

--- a/src/pages/VaultWithdrawalTutorial.tsx
+++ b/src/pages/VaultWithdrawalTutorial.tsx
@@ -36,7 +36,7 @@ const VaultWithdrawalTutorial = () => {
 
       <div className="container max-w-3xl px-4 py-8 md:py-12 space-y-6 md:space-y-8">
         {/* Back Navigation */}
-        <Link to="/vault-access" className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors text-sm">
+        <Link to="/vault-access" className="inline-flex items-center gap-2 text-white/50 hover:text-foreground transition-colors text-sm">
           <ArrowLeft className="h-4 w-4" />
           Back to Vault Access
         </Link>
@@ -48,7 +48,7 @@ const VaultWithdrawalTutorial = () => {
             Tutorial
           </Badge>
           <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight">How to Withdraw from the 3EA Vault</h1>
-          <p className="text-base md:text-lg text-muted-foreground">
+          <p className="text-base md:text-lg text-white/50">
             A complete guide to redeeming your vault shares and getting your funds back.
           </p>
 
@@ -92,7 +92,7 @@ const VaultWithdrawalTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               Navigate to the 3EA vault on Enzyme Finance and connect the same wallet you used to deposit.
             </p>
             
@@ -141,7 +141,7 @@ const VaultWithdrawalTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               Before withdrawing, review the current value of your vault shares.
             </p>
             
@@ -160,7 +160,7 @@ const VaultWithdrawalTutorial = () => {
               </div>
             </div>
 
-            <Alert variant="default" className="bg-muted/50">
+            <Alert variant="default" className="bg-white/5">
               <div className="flex gap-3">
                 <DollarSign className="h-4 w-4 shrink-0 mt-0.5" />
                 <p className="text-sm">
@@ -188,7 +188,7 @@ const VaultWithdrawalTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               Click the Redeem button to start the withdrawal process.
             </p>
             
@@ -237,7 +237,7 @@ const VaultWithdrawalTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               MetaMask will pop up asking you to confirm the redemption transaction.
             </p>
             
@@ -260,7 +260,7 @@ const VaultWithdrawalTutorial = () => {
               </div>
             </div>
 
-            <Alert variant="default" className="bg-muted/50">
+            <Alert variant="default" className="bg-white/5">
               <div className="flex gap-3">
                 <Clock className="h-4 w-4 shrink-0 mt-0.5" />
                 <p className="text-sm">
@@ -288,7 +288,7 @@ const VaultWithdrawalTutorial = () => {
             </div>
           </CardHeader>
           <CardContent className="space-y-4 p-4 pt-0 md:p-6 md:pt-0">
-            <p className="text-sm md:text-base text-muted-foreground">
+            <p className="text-sm md:text-base text-white/50">
               Once the transaction is confirmed, your funds will appear in your MetaMask wallet.
             </p>
             
@@ -320,7 +320,7 @@ const VaultWithdrawalTutorial = () => {
               <CheckCircle2 className="h-5 w-5 md:h-6 md:w-6 text-green-500 shrink-0" />
               <div>
                 <p className="font-semibold text-sm md:text-base">Withdrawal Complete!</p>
-                <p className="text-xs md:text-sm text-muted-foreground">
+                <p className="text-xs md:text-sm text-white/50">
                   Your funds are now back in your wallet. You can re-deposit at any time as long as you still hold the access NFT.
                 </p>
               </div>

--- a/supabase/functions/send-founding33-confirmation/index.ts
+++ b/supabase/functions/send-founding33-confirmation/index.ts
@@ -88,7 +88,7 @@ serve(async (req) => {
         Dear ${displayName},
       </p>
       <p style="color: #d4d4d4; font-size: 16px; line-height: 1.6; margin: 0 0 20px;">
-        Congratulations on becoming one of the <strong style="color: #f59e0b;">Founding 33</strong> – an exclusive group of visionaries who believed in the 3rd Eye Advisors mission from the very beginning.
+        Congratulations on becoming one of the <strong style="color: #f59e0b;">Founding 33</strong> – an exclusive group of visionaries who believed in the 3rdeyeadvisors mission from the very beginning.
       </p>
       <p style="color: #d4d4d4; font-size: 16px; line-height: 1.6; margin: 0;">
         Your seat number <strong style="color: #f59e0b;">#${seat_number}</strong> is permanently yours. This is your genesis mark in the 3EA ecosystem.
@@ -158,7 +158,7 @@ serve(async (req) => {
         Welcome to the inner circle. We're honored to have you.
       </p>
       <p style="color: #6b7280; font-size: 12px; margin: 0;">
-        3rd Eye Advisors • DeFi Education for the Awakened
+        3rdeyeadvisors • DeFi Education for the Awakened
       </p>
     </div>
 
@@ -168,7 +168,7 @@ serve(async (req) => {
     `;
 
     const { data, error } = await resend.emails.send({
-      from: "3rd Eye Advisors <founder@the3rdeyeadvisors.com>",
+      from: "3rdeyeadvisors <founder@the3rdeyeadvisors.com>",
       to: [customer_email],
       subject: `🎉 Welcome to the Founding 33 – Seat #${seat_number} is Yours!`,
       html: emailHtml,

--- a/supabase/functions/send-new-course-announcement/index.ts
+++ b/supabase/functions/send-new-course-announcement/index.ts
@@ -205,7 +205,7 @@ serve(async (req) => {
     <!-- Footer -->
     <div style="text-align: center; padding-top: 20px; border-top: 1px solid #333;">
       <p style="color: #6b7280; font-size: 12px; margin: 0;">
-        3rd Eye Advisors • DeFi Education for the Awakened
+        3rdeyeadvisors • DeFi Education for the Awakened
       </p>
     </div>
 
@@ -216,7 +216,7 @@ serve(async (req) => {
 
       try {
         await resend.emails.send({
-          from: "3rd Eye Advisors <courses@the3rdeyeadvisors.com>",
+          from: "3rdeyeadvisors <courses@the3rdeyeadvisors.com>",
           to: [recipient.email],
           subject: `🎓 New Course Available: ${course_title} — You Have Early Access!`,
           html: emailHtml,

--- a/supabase/functions/send-raffle-announcement/index.ts
+++ b/supabase/functions/send-raffle-announcement/index.ts
@@ -120,7 +120,6 @@ const handler = async (req: Request): Promise<Response> => {
                                   ✅ <strong>Follow us on Instagram</strong> @3rdeyeadvisors
                                 </p>
                                 <p style="font-size: 16px; line-height: 2; color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; margin: 8px 0;">
-                                  ✅ <strong>Follow us on X (Twitter)</strong> @3rdeyeadvisors
                                 </p>
                                 <p style="font-size: 16px; line-height: 2; color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; margin: 8px 0;">
                                   ✅ <strong>Subscribe to the newsletter</strong> (you're already in! 🎉)

--- a/supabase/functions/send-social-verification-email/index.ts
+++ b/supabase/functions/send-social-verification-email/index.ts
@@ -50,7 +50,7 @@ const handler = async (req: Request): Promise<Response> => {
     }
 
     const displayName = profile?.display_name || "there";
-    const platform = taskType === 'instagram' ? 'Instagram' : 'X (Twitter)';
+    const platform = 'Instagram';
     const platformHandle = taskType === 'instagram' ? '@3rdeyeadvisors' : '@3rdeyeadvisors';
 
     const emailHtml = `


### PR DESCRIPTION
This comprehensive patch addresses multiple critical and aesthetic issues identified in a platform-wide audit:

1. **NotesEditor Fix**: Resolved a critical bug where typing in the personal notes editor would cause the state to reset every 800ms due to parent re-renders triggering an aggressive `useEffect`. The fix uses `hasInitialized` and `prevInitialRef` to ensure state is only synchronized when the module actually changes.

2. **Legacy Token Sweep**: Migrated dozens of components and pages from legacy theme tokens (`bg-muted`, `text-muted-foreground`, `border-border`) to the new standardized system (`bg-white/5`, `text-white/50`, `border-white/8`). This ensures a consistent institutional-grade design aesthetic across the platform.

3. **Fullscreen Visibility**: Updated `FullscreenContentViewer.tsx` to use `bg-[#080808]` instead of `bg-background` (pure black), ensuring the content viewer remains visible and provides proper contrast against the global galaxy background.

4. **Email & Branding**: Standardized the brand name as "3rdeyeadvisors" in several Supabase Edge Functions and removed all references to X (Twitter) in automated emails, aligning with the platform's social media shift to Instagram.

5. **CSS Cleanup**: Fixed accidental artifacts from the token sweep (like double opacity modifiers) to ensure zero CSS invalidity.

The changes were verified visually via Playwright screenshots and programmatically through a successful `npm run build`.

---
*PR created automatically by Jules for task [15368279227851286144](https://jules.google.com/task/15368279227851286144) started by @3rdeyeadvisors*