### PR TITLE
Legacy Token Final Sweep — User-Facing Components

### DIFF
--- a/src/components/CryptoPricesWidget.tsx
+++ b/src/components/CryptoPricesWidget.tsx
@@ -86,7 +86,7 @@ const CryptoCard = ({ crypto, isRecommended = false }: { crypto: CryptoData; isR
                 <Star className="w-3.5 h-3.5 text-primary fill-primary" />
               )}
             </div>
-            <span className="text-xs text-muted-foreground font-consciousness truncate max-w-[120px] sm:max-w-[80px] block">
+            <span className="text-xs text-white/50 font-consciousness truncate max-w-[120px] sm:max-w-[80px] block">
               {crypto.name}
             </span>
           </div>
@@ -120,7 +120,7 @@ const CryptoCard = ({ crypto, isRecommended = false }: { crypto: CryptoData; isR
           )}
         </div>
         
-        <div className="text-xs text-muted-foreground font-consciousness">
+        <div className="text-xs text-white/50 font-consciousness">
           MCap: {formatMarketCap(crypto.marketCap)}
         </div>
       </div>
@@ -129,7 +129,7 @@ const CryptoCard = ({ crypto, isRecommended = false }: { crypto: CryptoData; isR
 };
 
 const LoadingSkeleton = () => (
-  <Card className="p-4 bg-card/80 border-border">
+  <Card className="p-4 bg-white/3 border-white/8">
     <div className="flex flex-col sm:flex-row items-center sm:items-start sm:justify-between mb-3 gap-2 sm:gap-0">
       <div className="flex flex-col sm:flex-row items-center gap-2">
         <Skeleton className="w-10 h-10 sm:w-8 sm:h-8 rounded-full" />
@@ -213,14 +213,14 @@ export const CryptoPricesWidget = () => {
 
   if (loading) {
     return (
-      <Card className="p-6 bg-card/60 border-border">
+      <Card className="p-6 bg-white/3 border-white/8">
         {/* Loading Header - Centered on mobile */}
         <div className="flex flex-col items-center sm:flex-row sm:items-center sm:justify-between mb-6 gap-4 text-center sm:text-left">
           <div className="flex flex-col sm:flex-row items-center gap-3">
             <Coins className="w-8 h-8 text-primary" />
             <div>
               <h2 className="text-2xl font-consciousness font-bold text-foreground">Live Crypto Prices</h2>
-              <p className="text-sm text-muted-foreground font-consciousness">Loading market data...</p>
+              <p className="text-sm text-white/50 font-consciousness">Loading market data...</p>
             </div>
           </div>
         </div>
@@ -254,13 +254,13 @@ export const CryptoPricesWidget = () => {
 
   if (error && !data) {
     return (
-      <Card className="p-6 bg-card/60 border-border">
+      <Card className="p-6 bg-white/3 border-white/8">
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <AlertTriangle className="w-12 h-12 text-amber-500 mb-4" />
           <h3 className="text-lg font-consciousness font-semibold text-foreground mb-2">
             Unable to Load Prices
           </h3>
-          <p className="text-muted-foreground font-consciousness mb-4">{error}</p>
+          <p className="text-white/50 font-consciousness mb-4">{error}</p>
           <Button onClick={() => fetchPrices(true)} variant="outline" className="min-h-[52px]">
             <RefreshCw className="w-4 h-4 mr-2" />
             Try Again
@@ -278,7 +278,7 @@ export const CryptoPricesWidget = () => {
           <Coins className="w-8 h-8 text-primary" />
           <div>
             <h2 className="text-2xl font-consciousness font-bold text-foreground">Live Crypto Prices</h2>
-            <div className="flex flex-col sm:flex-row items-center gap-2 text-sm text-muted-foreground font-consciousness">
+            <div className="flex flex-col sm:flex-row items-center gap-2 text-sm text-white/50 font-consciousness">
               {lastUpdated && (
                 <span>Updated at {formatLastUpdated(lastUpdated)}</span>
               )}

--- a/src/components/DefiCharts.tsx
+++ b/src/components/DefiCharts.tsx
@@ -442,12 +442,12 @@ export const DefiCharts = () => {
       <div className="block md:hidden space-y-4">
         <Card>
           <CardHeader className="flex flex-col items-center justify-center space-y-2 pb-2">
-            <DollarSign className="h-4 w-4 text-muted-foreground" />
+            <DollarSign className="h-4 w-4 text-white/50" />
             <CardTitle className="text-sm font-medium text-center">Total Value Locked</CardTitle>
           </CardHeader>
           <CardContent className="text-center">
             <div className="text-2xl font-bold">{formatCurrency(getCurrentTVL())}</div>
-            <div className="flex items-center justify-center text-xs text-muted-foreground">
+            <div className="flex items-center justify-center text-xs text-white/50">
               {parseFloat(getTVLChange()) >= 0 ? (
                 <TrendingUp className="w-4 h-4 text-awareness mr-1" />
               ) : (
@@ -473,7 +473,7 @@ export const DefiCharts = () => {
                 <h3 className="text-lg font-semibold text-foreground">
                   Explore Full Analytics on Desktop
                 </h3>
-                <p className="text-sm text-muted-foreground max-w-xs mx-auto">
+                <p className="text-sm text-white/50 max-w-xs mx-auto">
                   Access comprehensive charts, risk analysis, and detailed protocol data on desktop.
                 </p>
               </div>
@@ -649,7 +649,7 @@ export const DefiCharts = () => {
                           <CarouselItem key={slideIndex}>
                             <div className="space-y-4 overflow-y-auto h-full pr-2">
                               {data.protocols.slice(slideIndex * 4, (slideIndex + 1) * 4).map((protocol, index) => (
-                                <div key={protocol.id} className="p-4 rounded-lg border hover:bg-muted/50 transition-colors">
+                                <div key={protocol.id} className="p-4 rounded-lg border hover:bg-white/5 transition-colors">
                                   <div className="flex items-center justify-between gap-3">
                                     {/* Protocol info */}
                                     <div className="flex items-center gap-3 flex-1">
@@ -671,7 +671,7 @@ export const DefiCharts = () => {
                                             {protocol.category}
                                           </Badge>
                                         </div>
-                                        <div className="text-sm text-muted-foreground">
+                                        <div className="text-sm text-white/50">
                                           TVL: <span className="font-mono font-semibold">{formatCurrency(protocol.tvl)}</span>
                                         </div>
                                       </div>
@@ -681,7 +681,7 @@ export const DefiCharts = () => {
                                     <div className="flex items-center gap-4">
                                       <div className="flex gap-4">
                                         <div className="text-center">
-                                          <div className="text-xs text-muted-foreground mb-1">24h</div>
+                                          <div className="text-xs text-white/50 mb-1">24h</div>
                                           <div className={`flex items-center text-sm font-mono ${protocol.change_1d >= 0 ? 'text-awareness' : 'text-destructive'}`}>
                                             {protocol.change_1d >= 0 ? (
                                               <TrendingUp className="w-3 h-3 mr-1" />
@@ -692,7 +692,7 @@ export const DefiCharts = () => {
                                           </div>
                                         </div>
                                         <div className="text-center">
-                                          <div className="text-xs text-muted-foreground mb-1">7d</div>
+                                          <div className="text-xs text-white/50 mb-1">7d</div>
                                           <div className={`flex items-center text-sm font-mono ${protocol.change_7d >= 0 ? 'text-awareness' : 'text-destructive'}`}>
                                             {protocol.change_7d >= 0 ? (
                                               <TrendingUp className="w-3 h-3 mr-1" />
@@ -730,7 +730,7 @@ export const DefiCharts = () => {
                       {/* Navigation controls inside the carousel */}
                       <div className="absolute -bottom-16 left-1/2 transform -translate-x-1/2 flex items-center gap-2">
                         <CarouselPrevious />
-                        <span className="text-xs text-muted-foreground px-2">
+                        <span className="text-xs text-white/50 px-2">
                           {currentSlide + 1} of {Math.ceil(data.protocols.length / 4)}
                         </span>
                         <CarouselNext />
@@ -740,7 +740,7 @@ export const DefiCharts = () => {
                   
                   {/* Progress Bar Indicator */}
                   <div className="space-y-3 mt-16 flex-shrink-0">
-                    <div className="w-full bg-muted rounded-full h-2">
+                    <div className="w-full bg-white/5 rounded-full h-2">
                       <div className="flex h-full rounded-full overflow-hidden">
                         {Array.from({ length: Math.ceil(data.protocols.length / 4) }, (_, index) => (
                           <button
@@ -762,7 +762,7 @@ export const DefiCharts = () => {
                 {/* Mobile Carousel */}
                 <MobileCarouselWrapper>
                   {data.protocols.slice(0, 8).map((protocol, index) => (
-                    <div key={protocol.id} className="p-3 rounded-lg border bg-card text-center">
+                    <div key={protocol.id} className="p-3 rounded-lg border bg-white/3 text-center">
                       <div className="flex flex-col items-center gap-2 mb-3">
                         <div className="w-7 h-7 rounded-full bg-primary/10 border border-primary/20 flex items-center justify-center text-xs font-bold text-primary">
                           {index + 1}
@@ -782,19 +782,19 @@ export const DefiCharts = () => {
                       </div>
                       
                       <div className="space-y-3">
-                        <div className="text-sm text-muted-foreground text-center">
+                        <div className="text-sm text-white/50 text-center">
                           TVL: <span className="font-mono font-semibold text-foreground">{formatCurrency(protocol.tvl)}</span>
                         </div>
                         
                         <div className="flex justify-center gap-6 text-sm">
                           <div className="text-center">
-                            <div className="text-xs text-muted-foreground">24h</div>
+                            <div className="text-xs text-white/50">24h</div>
                             <div className={`font-mono font-medium ${protocol.change_1d >= 0 ? 'text-awareness' : 'text-destructive'}`}>
                               {protocol.change_1d >= 0 ? '+' : ''}{protocol.change_1d.toFixed(1)}%
                             </div>
                           </div>
                           <div className="text-center">
-                            <div className="text-xs text-muted-foreground">7d</div>
+                            <div className="text-xs text-white/50">7d</div>
                             <div className={`font-mono font-medium ${protocol.change_7d >= 0 ? 'text-awareness' : 'text-destructive'}`}>
                               {protocol.change_7d >= 0 ? '+' : ''}{protocol.change_7d.toFixed(1)}%
                             </div>
@@ -821,7 +821,7 @@ export const DefiCharts = () => {
                 </MobileCarouselWrapper>
               </>
             ) : (
-              <div className="flex items-center justify-center h-[300px] text-muted-foreground">
+              <div className="flex items-center justify-center h-[300px] text-white/50">
                 <div className="text-center">
                   <BarChart3 className="w-12 h-12 mx-auto mb-4 opacity-50" />
                   <p>Protocol data loading...</p>
@@ -877,7 +877,7 @@ export const DefiCharts = () => {
                   <span className="text-2xl font-bold text-foreground">
                     {data.riskDistribution.reduce((sum, item) => sum + item.value, 0)}%
                   </span>
-                  <span className="text-xs text-muted-foreground">Top 10 TVL</span>
+                  <span className="text-xs text-white/50">Top 10 TVL</span>
                 </div>
               </div>
               
@@ -896,7 +896,7 @@ export const DefiCharts = () => {
                       <span className="text-sm font-mono font-semibold text-foreground">{entry.value}%</span>
                     </div>
                     {/* Progress bar */}
-                    <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                    <div className="h-1.5 bg-white/5 rounded-full overflow-hidden">
                       <div 
                         className="h-full rounded-full transition-all duration-500"
                         style={{ 

--- a/src/components/community/OptimizedComments.tsx
+++ b/src/components/community/OptimizedComments.tsx
@@ -304,7 +304,7 @@ export const OptimizedComments = ({ contentType, contentId, title }: CommentsPro
                   <span className="font-medium text-sm">
                     {profile.display_name || 'Anonymous User'}
                   </span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-xs text-white/50">
                     {formatDate(comment.created_at)}
                   </span>
                   {comment.is_helpful && (
@@ -322,7 +322,7 @@ export const OptimizedComments = ({ contentType, contentId, title }: CommentsPro
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="text-xs text-muted-foreground hover:text-primary"
+                    className="text-xs text-white/50 hover:text-primary"
                     onClick={() => handleLikeComment(comment.id, comment.user_liked || false)}
                   >
                     <Heart className={`w-4 h-4 mr-1 ${comment.user_liked ? 'fill-red-500 text-red-500' : ''}`} />
@@ -333,7 +333,7 @@ export const OptimizedComments = ({ contentType, contentId, title }: CommentsPro
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-xs text-muted-foreground hover:text-primary"
+                      className="text-xs text-white/50 hover:text-primary"
                       onClick={() => setReplyingTo(replyingTo === comment.id ? null : comment.id)}
                     >
                       <Reply className="w-4 h-4 mr-1" />
@@ -345,7 +345,7 @@ export const OptimizedComments = ({ contentType, contentId, title }: CommentsPro
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-xs text-muted-foreground hover:text-primary"
+                      className="text-xs text-white/50 hover:text-primary"
                       onClick={() => toggleReplies(comment.id)}
                     >
                       {expandedComments.has(comment.id) ? (
@@ -410,10 +410,10 @@ export const OptimizedComments = ({ contentType, contentId, title }: CommentsPro
     return (
       <div className="space-y-4">
         <div className="animate-pulse">
-          <div className="h-4 bg-muted rounded w-1/4 mb-4"></div>
+          <div className="h-4 bg-white/5 rounded w-1/4 mb-4"></div>
           <div className="space-y-3">
-            <div className="h-20 bg-muted rounded"></div>
-            <div className="h-20 bg-muted rounded"></div>
+            <div className="h-20 bg-white/5 rounded"></div>
+            <div className="h-20 bg-white/5 rounded"></div>
           </div>
         </div>
       </div>
@@ -459,7 +459,7 @@ export const OptimizedComments = ({ contentType, contentId, title }: CommentsPro
         ) : (
           <Card className="mb-6">
             <CardContent className="p-4 text-center">
-              <p className="text-muted-foreground mb-3">Sign in to join the discussion</p>
+              <p className="text-white/50 mb-3">Sign in to join the discussion</p>
               <Button variant="outline" onClick={() => navigate('/auth')}>
                 Sign In
               </Button>
@@ -477,8 +477,8 @@ export const OptimizedComments = ({ contentType, contentId, title }: CommentsPro
         ) : (
           <Card>
             <CardContent className="p-8 text-center">
-              <MessageSquare className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-              <p className="text-muted-foreground">
+              <MessageSquare className="w-12 h-12 text-white/50 mx-auto mb-4" />
+              <p className="text-white/50">
                 No comments yet. Be the first to share your thoughts!
               </p>
             </CardContent>

--- a/src/components/community/RatingReviews.tsx
+++ b/src/components/community/RatingReviews.tsx
@@ -214,7 +214,7 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
               className={`w-5 h-5 transition-colors ${
                 star <= rating 
                   ? 'fill-yellow-500 text-yellow-500' 
-                  : 'fill-none text-muted-foreground'
+                  : 'fill-none text-white/50'
               }`}
               style={{ textDecoration: 'none' }}
             />
@@ -236,8 +236,8 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
     return (
       <div className="space-y-4">
         <div className="animate-pulse">
-          <div className="h-6 bg-muted rounded w-1/3 mb-4"></div>
-          <div className="h-20 bg-muted rounded"></div>
+          <div className="h-6 bg-white/5 rounded w-1/3 mb-4"></div>
+          <div className="h-20 bg-white/5 rounded"></div>
         </div>
       </div>
     );
@@ -260,7 +260,7 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
                   {stats.averageRating.toFixed(1)}
                 </div>
                 <StarRating rating={Math.round(stats.averageRating)} />
-                <p className="text-sm text-muted-foreground mt-2">
+                <p className="text-sm text-white/50 mt-2">
                   Based on {stats.totalReviews} {stats.totalReviews === 1 ? 'review' : 'reviews'}
                 </p>
               </div>
@@ -271,7 +271,7 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
                   <div key={stars} className="flex items-center gap-2">
                     <span className="text-sm w-6">{stars}</span>
                     <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
-                    <div className="flex-1 bg-muted rounded-full h-2">
+                    <div className="flex-1 bg-white/5 rounded-full h-2">
                       <div
                         className="bg-accent h-2 rounded-full"
                         style={{
@@ -279,7 +279,7 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
                         }}
                       />
                     </div>
-                    <span className="text-sm text-muted-foreground w-8">
+                    <span className="text-sm text-white/50 w-8">
                       {stats.distribution[stars - 1]}
                     </span>
                   </div>
@@ -302,7 +302,7 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
                 <div className="space-y-3">
                   <StarRating rating={userRating.rating} />
                   {userRating.review_text && (
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-sm text-white/50">
                       "{userRating.review_text}"
                     </p>
                   )}
@@ -387,7 +387,7 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
                             </span>
                             <StarRating rating={rating.rating} />
                           </div>
-                          <span className="text-xs text-muted-foreground">
+                          <span className="text-xs text-white/50">
                             {formatDate(rating.created_at)}
                           </span>
                         </div>
@@ -405,7 +405,7 @@ export const RatingReviews = ({ contentType, contentId, title }: RatingStatsProp
         {!user && (
           <Card>
             <CardContent className="p-6 text-center">
-              <p className="text-muted-foreground mb-3">
+              <p className="text-white/50 mb-3">
                 Sign in to rate and review this content
               </p>
               <Button variant="outline" onClick={() => navigate('/auth')}>

--- a/src/components/course/ContentPlayer.tsx
+++ b/src/components/course/ContentPlayer.tsx
@@ -155,7 +155,7 @@ export const ContentPlayer = ({
       case 'video': return 'bg-destructive/20 text-destructive border-destructive/30';
       case 'text': return 'bg-primary/20 text-primary border-primary/30';
       case 'interactive': return 'bg-awareness/20 text-awareness border-awareness/30';
-      default: return 'bg-muted text-muted-foreground border-border';
+      default: return 'bg-white/5 text-white/50 border-white/8';
     }
   };
 
@@ -168,7 +168,7 @@ export const ContentPlayer = ({
             <Badge className={getTypeColor(module.type)}>
               {getTypeIcon(module.type)} {module.type.charAt(0).toUpperCase() + module.type.slice(1)}
             </Badge>
-            <div className="flex items-center gap-2 text-muted-foreground">
+            <div className="flex items-center gap-2 text-white/50">
               <Clock className="w-4 h-4" />
               <span className="text-sm">{module.duration} min</span>
             </div>
@@ -185,7 +185,7 @@ export const ContentPlayer = ({
               variant="ghost"
               size="sm"
               onClick={toggleBookmark}
-              className="text-muted-foreground hover:text-foreground"
+              className="text-white/50 hover:text-foreground"
             >
               {isBookmarked ? (
                 <BookmarkCheck className="w-4 h-4" />
@@ -193,7 +193,7 @@ export const ContentPlayer = ({
                 <Bookmark className="w-4 h-4" />
               )}
             </Button>
-            <span className="text-sm text-muted-foreground">
+            <span className="text-sm text-white/50">
               {currentModuleIndex + 1} of {totalModules}
             </span>
           </div>
@@ -207,8 +207,8 @@ export const ContentPlayer = ({
         {module.type === 'text' && (
           <div className="mb-4">
             <div className="flex items-center justify-between mb-2">
-              <span className="text-sm text-muted-foreground">Reading Progress</span>
-              <span className="text-sm text-muted-foreground">{Math.round(readingProgress)}%</span>
+              <span className="text-sm text-white/50">Reading Progress</span>
+              <span className="text-sm text-white/50">{Math.round(readingProgress)}%</span>
             </div>
             <Progress value={readingProgress} className="h-2" />
           </div>
@@ -228,11 +228,11 @@ export const ContentPlayer = ({
           )}
 
           {module.type === 'video' && module.content.videoUrl && (
-            <div className="aspect-video bg-background/95 border-2 border-border rounded-lg flex items-center justify-center">
+            <div className="aspect-video bg-black/95 border-2 border-white/8 rounded-lg flex items-center justify-center">
               <div className="text-foreground text-center">
                 <div className="text-4xl mb-4">🎥</div>
                 <p className="text-lg">Video Player</p>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm text-white/50">
                   In a real implementation, this would be a video player
                 </p>
                 <Button 
@@ -258,7 +258,7 @@ export const ContentPlayer = ({
             </h3>
             <div className="space-y-3">
               {module.resources.map((resource, index) => (
-                <div key={index} className="flex items-center justify-between p-3 bg-muted rounded-lg">
+                <div key={index} className="flex items-center justify-between p-3 bg-white/5 rounded-lg">
                   <div className="flex items-center gap-3">
                     {resource.type === 'pdf' && <FileText className="w-4 h-4 text-red-600" />}
                     {resource.type === 'link' && <ExternalLink className="w-4 h-4 text-blue-600" />}
@@ -309,7 +309,7 @@ export const ContentPlayer = ({
         </div>
 
         <div className="flex items-center gap-4">
-          <div className="text-sm text-muted-foreground">
+          <div className="text-sm text-white/50">
             Time spent: {timeSpent} min{timeSpent !== 1 ? 's' : ''}
           </div>
           

--- a/src/components/course/EnhancedModuleNavigation.tsx
+++ b/src/components/course/EnhancedModuleNavigation.tsx
@@ -107,7 +107,7 @@ export const EnhancedModuleNavigation = ({
       case 'video': return 'text-destructive bg-destructive/10 border-destructive/20';
       case 'text': return 'text-primary bg-primary/10 border-primary/20';
       case 'interactive': return 'text-awareness bg-awareness/10 border-awareness/20';
-      default: return 'text-muted-foreground bg-muted/50 border-border';
+      default: return 'text-white/50 bg-white/5 border-white/8';
     }
   };
 
@@ -163,7 +163,7 @@ export const EnhancedModuleNavigation = ({
                   <p className="text-sm font-medium leading-snug pl-7">{module.title}</p>
                   
                   {/* Duration */}
-                  <p className="text-xs text-muted-foreground pl-7">{module.duration} min</p>
+                  <p className="text-xs text-white/50 pl-7">{module.duration} min</p>
                 </div>
               </Button>
             );
@@ -225,7 +225,7 @@ export const EnhancedModuleNavigation = ({
       <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-4 sm:mb-6">
         <div className="flex-1">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-3.5 h-3.5 sm:w-4 sm:h-4 text-muted-foreground pointer-events-none" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-3.5 h-3.5 sm:w-4 sm:h-4 text-white/50 pointer-events-none" />
             <Input
               placeholder="Search modules by title..."
               value={searchTerm}
@@ -235,7 +235,7 @@ export const EnhancedModuleNavigation = ({
             />
           </div>
           {searchTerm && filteredModules.length > 0 && (
-            <p className="text-xs sm:text-sm text-muted-foreground mt-1.5 sm:mt-2">
+            <p className="text-xs sm:text-sm text-white/50 mt-1.5 sm:mt-2">
               Found {filteredModules.length} module{filteredModules.length !== 1 ? 's' : ''}
             </p>
           )}
@@ -251,17 +251,17 @@ export const EnhancedModuleNavigation = ({
                 <ChevronDown className="w-3.5 h-3.5 sm:w-4 sm:h-4 ml-1.5 sm:ml-2" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="bg-card border-border z-50">
-              <DropdownMenuItem onClick={() => setFilterType('all')} className="hover:bg-muted cursor-pointer text-xs sm:text-sm">
+            <DropdownMenuContent className="bg-white/3 border-white/8 z-50">
+              <DropdownMenuItem onClick={() => setFilterType('all')} className="hover:bg-white/5 cursor-pointer text-xs sm:text-sm">
                 All Types
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setFilterType('text')} className="hover:bg-muted cursor-pointer text-xs sm:text-sm">
+              <DropdownMenuItem onClick={() => setFilterType('text')} className="hover:bg-white/5 cursor-pointer text-xs sm:text-sm">
                 Text Only
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setFilterType('video')} className="hover:bg-muted cursor-pointer text-xs sm:text-sm">
+              <DropdownMenuItem onClick={() => setFilterType('video')} className="hover:bg-white/5 cursor-pointer text-xs sm:text-sm">
                 Video Only
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setFilterType('interactive')} className="hover:bg-muted cursor-pointer text-xs sm:text-sm">
+              <DropdownMenuItem onClick={() => setFilterType('interactive')} className="hover:bg-white/5 cursor-pointer text-xs sm:text-sm">
                 Interactive Only
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -345,8 +345,8 @@ export const EnhancedModuleNavigation = ({
 
       {filteredModules.length === 0 && (
         <div className="text-center py-6 sm:py-8">
-          <BookOpen className="w-10 h-10 sm:w-12 sm:h-12 text-muted-foreground mx-auto mb-3 sm:mb-4" />
-          <p className="text-muted-foreground text-sm sm:text-base">No modules match your search criteria.</p>
+          <BookOpen className="w-10 h-10 sm:w-12 sm:h-12 text-white/50 mx-auto mb-3 sm:mb-4" />
+          <p className="text-white/50 text-sm sm:text-base">No modules match your search criteria.</p>
         </div>
       )}
     </Card>

--- a/src/components/landing/PricingSection.tsx
+++ b/src/components/landing/PricingSection.tsx
@@ -59,7 +59,7 @@ const PricingSection = () => {
           <h2 className="text-3xl md:text-5xl font-consciousness font-bold text-foreground mb-6">
             Start Your Journey Risk Free
           </h2>
-          <p className="text-lg text-muted-foreground font-body max-w-2xl mx-auto">
+          <p className="text-lg text-white/50 font-body max-w-2xl mx-auto">
             Try everything free for 14 days. Cancel anytime.
           </p>
         </AnimatedSection>
@@ -67,18 +67,18 @@ const PricingSection = () => {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5 lg:gap-6 max-w-4xl mx-auto">
           {/* Monthly Plan */}
           <AnimatedSection animation="fade-left" delay={0}>
-            <div className="relative h-full p-5 md:p-6 lg:p-8 rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm hover:border-primary/30 transition-all duration-300 group">
+            <div className="relative h-full p-5 md:p-6 lg:p-8 rounded-2xl border border-white/8 bg-white/3 backdrop-blur-sm hover:border-primary/30 transition-all duration-300 group">
               <div className="flex flex-col h-full">
                 <div className="text-center mb-6">
                   <h3 className="text-lg font-consciousness font-semibold text-foreground mb-2">
                     Monthly
                   </h3>
-                  <p className="text-sm text-muted-foreground font-body mb-4">
+                  <p className="text-sm text-white/50 font-body mb-4">
                     Full access billed monthly
                   </p>
                   <div className="mb-1">
                     <span className="text-4xl font-consciousness font-bold text-foreground">{PRICING.monthly.display}</span>
-                    <span className="text-muted-foreground font-body">{PRICING.monthly.period}</span>
+                    <span className="text-white/50 font-body">{PRICING.monthly.period}</span>
                   </div>
                 </div>
                 
@@ -100,7 +100,7 @@ const PricingSection = () => {
                 
                 <Button 
                   variant="outline"
-                  className="w-full font-body py-6 border-border hover:border-primary/50 hover:bg-primary/5"
+                  className="w-full font-body py-6 border-white/8 hover:border-primary/50 hover:bg-primary/5"
                   onClick={() => handleSubscribe('monthly')}
                   disabled={checkoutLoading !== null}
                 >
@@ -119,7 +119,7 @@ const PricingSection = () => {
 
           {/* Annual Plan */}
           <AnimatedSection animation="fade-right" delay={100}>
-            <div className="relative h-full p-5 md:p-6 lg:p-8 rounded-2xl border-2 border-primary/50 bg-card/50 backdrop-blur-sm group overflow-hidden">
+            <div className="relative h-full p-5 md:p-6 lg:p-8 rounded-2xl border-2 border-primary/50 bg-white/3 backdrop-blur-sm group overflow-hidden">
               {/* Premium badge */}
               <div className="absolute -top-px left-1/2 -translate-x-1/2">
                 <span className="inline-flex items-center gap-1.5 text-xs uppercase tracking-wider text-primary-foreground bg-primary px-4 py-1.5 rounded-b-lg font-medium">
@@ -136,12 +136,12 @@ const PricingSection = () => {
                   <h3 className="text-lg font-consciousness font-semibold text-foreground mb-2">
                     Annual
                   </h3>
-                  <p className="text-sm text-muted-foreground font-body mb-4">
+                  <p className="text-sm text-white/50 font-body mb-4">
                     Full year commitment
                   </p>
                   <div className="mb-1">
                     <span className="text-4xl font-consciousness font-bold text-foreground">{PRICING.annual.display}</span>
-                    <span className="text-muted-foreground font-body">{PRICING.annual.period}</span>
+                    <span className="text-white/50 font-body">{PRICING.annual.period}</span>
                   </div>
                 </div>
                 
@@ -182,7 +182,7 @@ const PricingSection = () => {
         </div>
 
         <AnimatedSection delay={200}>
-          <p className="text-center text-sm text-muted-foreground font-body mt-8">
+          <p className="text-center text-sm text-white/50 font-body mt-8">
             Cancel anytime during your trial. No questions asked.
           </p>
         </AnimatedSection>

--- a/src/components/points/PointsDisplay.tsx
+++ b/src/components/points/PointsDisplay.tsx
@@ -19,7 +19,7 @@ export const PointsDisplay = ({ compact = false }: PointsDisplayProps) => {
   if (loading) {
     return (
       <Card className="p-4 sm:p-6 bg-gradient-to-br from-primary/10 to-accent/10 border-primary/20 animate-pulse">
-        <div className="h-24 bg-muted rounded" />
+        <div className="h-24 bg-white/5 rounded" />
       </Card>
     );
   }
@@ -31,7 +31,7 @@ export const PointsDisplay = ({ compact = false }: PointsDisplayProps) => {
       <div className="flex items-center gap-2">
         <Star className="w-4 h-4 text-accent" />
         <span className="font-consciousness font-bold text-white">{totalPoints.toLocaleString()}</span>
-        <span className="text-xs text-muted-foreground font-body">pts</span>
+        <span className="text-xs text-white/50 font-body">pts</span>
       </div>
     );
   }
@@ -45,39 +45,39 @@ export const PointsDisplay = ({ compact = false }: PointsDisplayProps) => {
           </div>
           <div>
             <h3 className="font-consciousness font-bold text-white">Monthly Points</h3>
-            <p className="text-xs text-muted-foreground font-body">{currentMonth}</p>
+            <p className="text-xs text-white/50 font-body">{currentMonth}</p>
           </div>
         </div>
 
         {/* Main Stats */}
         <div className="grid grid-cols-3 gap-3 mb-4">
-          <div className="text-center p-3 bg-background/50 rounded-lg">
+          <div className="text-center p-3 bg-black/50 rounded-lg">
             <div className="text-2xl sm:text-3xl font-bold text-violet-400 font-consciousness">
               {totalPoints.toLocaleString()}
             </div>
-            <div className="text-xs text-muted-foreground font-body">Total Points</div>
+            <div className="text-xs text-white/50 font-body">Total Points</div>
           </div>
           
-          <div className="text-center p-3 bg-background/50 rounded-lg">
+          <div className="text-center p-3 bg-black/50 rounded-lg">
             <div className="flex items-center justify-center gap-1">
               <TrendingUp className="w-4 h-4 text-accent" />
               <span className="text-2xl sm:text-3xl font-bold text-violet-400 font-consciousness">
                 #{rank?.rank || '-'}
               </span>
             </div>
-            <div className="text-xs text-muted-foreground font-body">
+            <div className="text-xs text-white/50 font-body">
               of {rank?.total_users ? rank.total_users.toLocaleString() : '...'}
             </div>
           </div>
           
-          <div className="text-center p-3 bg-background/50 rounded-lg">
+          <div className="text-center p-3 bg-black/50 rounded-lg">
             <div className="flex items-center justify-center gap-1">
-              <Calendar className="w-4 h-4 text-muted-foreground" />
+              <Calendar className="w-4 h-4 text-white/50" />
               <span className="text-2xl sm:text-3xl font-bold text-violet-400 font-consciousness">
                 {daysRemaining}
               </span>
             </div>
-            <div className="text-xs text-muted-foreground font-body">Days Left</div>
+            <div className="text-xs text-white/50 font-body">Days Left</div>
           </div>
         </div>
 

--- a/src/components/roadmap/FeatureSuggestionForm.tsx
+++ b/src/components/roadmap/FeatureSuggestionForm.tsx
@@ -52,13 +52,13 @@ export const FeatureSuggestionForm = ({
   // Non-premium users see upgrade CTA
   if (!canSubmit) {
     return (
-      <Card className="border-border/50 bg-card/50 h-full">
+      <Card className="border-white/8 bg-white/3 h-full">
         <CardContent className="flex flex-col items-center justify-center py-6 px-4 text-center h-full">
-          <div className="w-10 h-10 rounded-full bg-muted/50 flex items-center justify-center mb-3">
-            <Lock className="w-5 h-5 text-muted-foreground" />
+          <div className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center mb-3">
+            <Lock className="w-5 h-5 text-white/50" />
           </div>
           <h3 className="text-base font-consciousness font-medium mb-1">Premium Feature</h3>
-          <p className="text-sm text-muted-foreground mb-4 max-w-sm">
+          <p className="text-sm text-white/50 mb-4 max-w-sm">
             Annual and Founding 33 members can submit feature ideas for consideration.
           </p>
           <Button asChild variant="outline" size="sm">
@@ -107,7 +107,7 @@ export const FeatureSuggestionForm = ({
               <div className="space-y-2">
                 <div className="flex items-center justify-between w-full text-left">
                   <label className="text-sm font-medium">Title</label>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-xs text-white/50">
                     {title.length}/{MAX_TITLE_LENGTH}
                   </span>
                 </div>
@@ -116,7 +116,7 @@ export const FeatureSuggestionForm = ({
                   value={title}
                   onChange={handleTitleChange}
                   disabled={submitting}
-                  className="bg-background"
+                  className="bg-black"
                 />
               </div>
 
@@ -124,7 +124,7 @@ export const FeatureSuggestionForm = ({
               <div className="space-y-2">
                 <div className="flex items-center justify-between w-full text-left">
                   <label className="text-sm font-medium">Description</label>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-xs text-white/50">
                     {description.length}/{MAX_DESCRIPTION_LENGTH}
                   </span>
                 </div>
@@ -134,7 +134,7 @@ export const FeatureSuggestionForm = ({
                   onChange={handleDescriptionChange}
                   disabled={submitting}
                   rows={4}
-                  className="bg-background resize-none"
+                  className="bg-black resize-none"
                 />
               </div>
 

--- a/src/pages/ChartReadingTutorial.tsx
+++ b/src/pages/ChartReadingTutorial.tsx
@@ -260,19 +260,19 @@ const ChartReadingTutorial = () => {
             <Card className="p-4 border-awareness/20 bg-awareness/10">
               <h4 className="font-semibold text-awareness mb-3">Bullish Patterns</h4>
               <div className="space-y-3">
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Cup and Handle</span>
                   <Badge variant="outline" className="text-awareness border-awareness/50 whitespace-nowrap text-xs">Continuation</Badge>
                 </div>
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Double Bottom</span>
                   <Badge variant="outline" className="text-awareness border-awareness/50 whitespace-nowrap text-xs">Reversal</Badge>
                 </div>
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Ascending Triangle</span>
                   <Badge variant="outline" className="text-awareness border-awareness/50 whitespace-nowrap text-xs">Continuation</Badge>
                 </div>
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Bull Flag</span>
                   <Badge variant="outline" className="text-awareness border-awareness/50 whitespace-nowrap text-xs">Continuation</Badge>
                 </div>
@@ -282,19 +282,19 @@ const ChartReadingTutorial = () => {
             <Card className="p-4 border-destructive/20 bg-destructive/10">
               <h4 className="font-semibold text-destructive mb-3">Bearish Patterns</h4>
               <div className="space-y-3">
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Head and Shoulders</span>
                   <Badge variant="outline" className="text-destructive border-destructive/50 whitespace-nowrap text-xs">Reversal</Badge>
                 </div>
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Double Top</span>
                   <Badge variant="outline" className="text-destructive border-destructive/50 whitespace-nowrap text-xs">Reversal</Badge>
                 </div>
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Descending Triangle</span>
                   <Badge variant="outline" className="text-destructive border-destructive/50 whitespace-nowrap text-xs">Continuation</Badge>
                 </div>
-                <div className="flex items-center justify-between gap-2 p-2 bg-background/20 rounded">
+                <div className="flex items-center justify-between gap-2 p-2 bg-black/20 rounded">
                   <span className="text-sm font-medium">Bear Flag</span>
                   <Badge variant="outline" className="text-destructive border-destructive/50 whitespace-nowrap text-xs">Continuation</Badge>
                 </div>

--- a/src/pages/LiquidityPoolBasicsTutorial.tsx
+++ b/src/pages/LiquidityPoolBasicsTutorial.tsx
@@ -679,7 +679,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Key Components</h3>
                   <div className="grid gap-3">
                     {currentStepData.content.keyComponents.map((comp, idx) => (
-                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                      <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-2">{comp.component}</h4>
                         <p className="text-sm text-white/50 mb-2">{comp.description}</p>
                         <p className="text-xs text-primary font-mono">{comp.example}</p>
@@ -725,7 +725,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Price Calculation Examples</h3>
                   <div className="space-y-3">
                     {currentStepData.content.priceCalculation.map((calc, idx) => (
-                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                      <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-3">{calc.scenario}</h4>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
                           <div>
@@ -780,7 +780,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Real Examples</h3>
                   <div className="space-y-3">
                     {currentStepData.content.examples.map((example, idx) => (
-                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                      <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-3 flex items-center gap-2">
                           {example.scenario}
                         </h4>
@@ -830,7 +830,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Pool Categories</h3>
                   <div className="space-y-3">
                     {currentStepData.content.poolCategories.map((cat, idx) => (
-                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                      <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                         <div className="flex items-center justify-between mb-3">
                           <h4 className="font-medium text-foreground">{cat.category}</h4>
                           <Badge variant="outline">{cat.apyRange} APY</Badge>
@@ -888,7 +888,7 @@ const LiquidityPoolBasicsTutorial = () => {
 
                 <div className="space-y-4">
                   {currentStepData.content.steps.map((step, idx) => (
-                    <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                    <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                       <div className="flex items-start gap-3">
                         <div className="bg-primary text-primary-foreground rounded-full w-8 h-8 flex items-center justify-center font-bold shrink-0">
                           {step.step}
@@ -979,7 +979,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Monitoring Metrics</h3>
                   <div className="space-y-3">
                     {currentStepData.content.monitoringMetrics.map((metric, idx) => (
-                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                      <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                         <div className="flex items-center justify-between mb-2">
                           <h4 className="font-medium text-foreground">{metric.metric}</h4>
                           <Badge variant="outline" className="text-xs">{metric.frequency}</Badge>
@@ -1029,7 +1029,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Advanced Strategies</h3>
                   <div className="space-y-3">
                     {currentStepData.content.strategies.map((strategy, idx) => (
-                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                      <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-foreground mb-2">{strategy.strategy}</h4>
                         <p className="text-sm text-white/50 mb-3">{strategy.description}</p>
                         <div className="space-y-1 text-sm">
@@ -1076,7 +1076,7 @@ const LiquidityPoolBasicsTutorial = () => {
                   <h3 className="font-semibold text-foreground text-lg">Common Mistakes</h3>
                   <div className="space-y-3">
                     {currentStepData.content.commonMistakes.map((mistake, idx) => (
-                      <div key={idx} className="bg-card border border-white/8 rounded-lg p-4">
+                      <div key={idx} className="bg-white/3 border border-white/8 rounded-lg p-4">
                         <h4 className="font-medium text-destructive mb-2">❌ {mistake.mistake}</h4>
                         <p className="text-sm text-white/50 mb-2">
                           <strong>Consequence:</strong> {mistake.consequence}

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -190,7 +190,7 @@ const ResetPassword = () => {
           <CardContent className="pt-6">
             <div className="flex items-center justify-center space-x-2">
               <Loader2 className="h-6 w-6 animate-spin text-primary" />
-              <span className="text-muted-foreground">Verifying reset link...</span>
+              <span className="text-white/50">Verifying reset link...</span>
             </div>
           </CardContent>
         </Card>
@@ -209,7 +209,7 @@ const ResetPassword = () => {
             <CardTitle className="text-2xl font-bold text-violet-400">
               Reset Your Password
             </CardTitle>
-            <CardDescription className="text-muted-foreground">
+            <CardDescription className="text-white/50">
               Create a new secure password for your 3rdeyeadvisors account
             </CardDescription>
           </div>
@@ -240,9 +240,9 @@ const ResetPassword = () => {
                   onClick={() => setShowPassword(!showPassword)}
                 >
                   {showPassword ? (
-                    <EyeOff className="h-4 w-4 text-muted-foreground" />
+                    <EyeOff className="h-4 w-4 text-white/50" />
                   ) : (
-                    <Eye className="h-4 w-4 text-muted-foreground" />
+                    <Eye className="h-4 w-4 text-white/50" />
                   )}
                 </Button>
               </div>
@@ -271,18 +271,18 @@ const ResetPassword = () => {
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 >
                   {showConfirmPassword ? (
-                    <EyeOff className="h-4 w-4 text-muted-foreground" />
+                    <EyeOff className="h-4 w-4 text-white/50" />
                   ) : (
-                    <Eye className="h-4 w-4 text-muted-foreground" />
+                    <Eye className="h-4 w-4 text-white/50" />
                   )}
                 </Button>
               </div>
             </div>
 
             {/* Password Requirements */}
-            <div className="bg-muted/50 border border-primary/20 rounded-lg p-4 space-y-2">
+            <div className="bg-white/5 border border-primary/20 rounded-lg p-4 space-y-2">
               <h4 className="text-sm font-medium text-foreground">Password Requirements:</h4>
-              <ul className="text-xs text-muted-foreground space-y-1">
+              <ul className="text-xs text-white/50 space-y-1">
                 <li className={newPassword.length >= 8 ? "text-primary" : ""}>
                   • At least 8 characters long
                 </li>
@@ -311,7 +311,7 @@ const ResetPassword = () => {
           <div className="text-center">
             <Button 
               variant="ghost" 
-              className="text-sm text-muted-foreground hover:text-primary"
+              className="text-sm text-white/50 hover:text-primary"
               onClick={() => navigate('/auth')}
             >
               Back to Sign In

--- a/src/pages/WhyMostPeopleLoseCrypto.tsx
+++ b/src/pages/WhyMostPeopleLoseCrypto.tsx
@@ -59,11 +59,11 @@ const WhyMostPeopleLoseCrypto = () => {
               Listen to this article
             </button>
 
-            <p className="text-lg text-muted-foreground font-consciousness mb-6 leading-relaxed">
+            <p className="text-lg text-white/50 font-consciousness mb-6 leading-relaxed">
               {blogPost.excerpt}
             </p>
 
-            <div className="flex flex-wrap items-center gap-6 text-sm text-muted-foreground">
+            <div className="flex flex-wrap items-center gap-6 text-sm text-white/50">
               <div className="flex items-center gap-2">
                 <User className="w-4 h-4" />
                 <span>{BRAND_AUTHOR}</span>
@@ -173,7 +173,7 @@ const WhyMostPeopleLoseCrypto = () => {
                     Beyond individual behavioral mistakes, 2022 exposed catastrophic failures in centralized crypto infrastructure. These were not market corrections. They were institutional failures that destroyed customer funds.
                   </p>
 
-                  <div className="bg-muted/30 rounded-lg p-6 mb-6">
+                  <div className="bg-white/5 rounded-lg p-6 mb-6">
                     <h3 className="text-xl font-semibold text-foreground mb-4">The Cascade of Failures</h3>
                     <ul className="space-y-3 text-foreground/90">
                       <li><strong className="text-foreground">Terra/Luna (May 2022):</strong> The algorithmic stablecoin UST lost its peg, triggering a death spiral that erased over $60 billion in market value within days. The collapse was triggered by fundamental design flaws in the algorithmic mechanism.</li>
@@ -206,28 +206,28 @@ const WhyMostPeopleLoseCrypto = () => {
                   </p>
 
                   <div className="grid md:grid-cols-2 gap-6 mb-6">
-                    <div className="bg-muted/30 rounded-lg p-5">
+                    <div className="bg-white/5 rounded-lg p-5">
                       <h3 className="text-lg font-semibold text-foreground mb-3">On-Chain Transparency</h3>
                       <p className="text-foreground/80 text-sm leading-relaxed">
                         Every transaction, every balance, every smart contract is publicly auditable. There's no hidden balance sheet, no commingled funds, no trust required. You can verify instead of trust.
                       </p>
                     </div>
                     
-                    <div className="bg-muted/30 rounded-lg p-5">
+                    <div className="bg-white/5 rounded-lg p-5">
                       <h3 className="text-lg font-semibold text-foreground mb-3">Self-Custody</h3>
                       <p className="text-foreground/80 text-sm leading-relaxed">
                         Your keys, your coins. DeFi protocols do not take custody of your assets. They execute programmable logic while you retain control. No counterparty can freeze, steal, or misappropriate your funds.
                       </p>
                     </div>
                     
-                    <div className="bg-muted/30 rounded-lg p-5">
+                    <div className="bg-white/5 rounded-lg p-5">
                       <h3 className="text-lg font-semibold text-foreground mb-3">Programmable Rules</h3>
                       <p className="text-foreground/80 text-sm leading-relaxed">
                         Smart contracts execute automatically based on code, not human discretion. Liquidation thresholds, interest rates, and collateral requirements operate transparently and predictably.
                       </p>
                     </div>
                     
-                    <div className="bg-muted/30 rounded-lg p-5">
+                    <div className="bg-white/5 rounded-lg p-5">
                       <h3 className="text-lg font-semibold text-foreground mb-3">Composability</h3>
                       <p className="text-foreground/80 text-sm leading-relaxed">
                         DeFi protocols can integrate with each other, creating financial systems that are open, interoperable, and resistant to single points of failure.
@@ -311,7 +311,7 @@ const WhyMostPeopleLoseCrypto = () => {
                     </li>
                   </ul>
 
-                  <div className="bg-muted/30 rounded-lg p-6">
+                  <div className="bg-white/5 rounded-lg p-6">
                     <p className="text-foreground/90 leading-relaxed text-center italic">
                       "The goal isn't to get rich quick. The goal is to understand what you're doing, why you're doing it, and to build a sustainable approach that survives both bull and bear markets."
                     </p>
@@ -327,7 +327,7 @@ const WhyMostPeopleLoseCrypto = () => {
                 </div>
 
                 {/* Disclaimer */}
-                <div className="border-t border-border/50 pt-8">
+                <div className="border-t border-white/8 pt-8">
                   <h2 className="text-lg font-semibold text-foreground mb-4">Educational Disclaimer</h2>
                   <p className="text-foreground/70 text-sm leading-relaxed">
                     This content is provided for educational and informational purposes only. It does not constitute financial advice, investment advice, trading advice, or any other type of advice. You should not treat any of the content as such. The 3rdeyeadvisors Research Team does not recommend that any cryptocurrency, token, or investment strategy is suitable for any specific person.


### PR DESCRIPTION
This submission completes the final sweep of legacy CSS tokens in the specified user-facing components and pages. 

Key changes include:
- `bg-muted` and `bg-muted/30` -> `bg-white/5`
- `bg-muted/80` -> `bg-white/8`
- `text-muted-foreground` -> `text-white/50`
- `border-border` -> `border-white/8`
- `bg-background` -> `bg-black`
- `bg-card` -> `bg-white/3`

Additional mappings were performed for common variants found in the target files (e.g., `bg-card/30` to `bg-white/3`) to maintain the integrity of the new design system. All changes were verified via `npm run build` and visual inspection of representative pages.

---
*PR created automatically by Jules for task [10084642812339566346](https://jules.google.com/task/10084642812339566346) started by @3rdeyeadvisors*