### PR TITLE
Standardize CSS Tokens Across 9 Files

### DIFF
--- a/src/components/AutomatedLayout.tsx
+++ b/src/components/AutomatedLayout.tsx
@@ -33,7 +33,7 @@ const AutomatedLayout = ({ children, showSEOValidator = true }: AutomatedLayoutP
   });
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-black flex flex-col">
       <PullToRefreshIndicator
         pullDistance={pullDistance}
         isRefreshing={isRefreshing}

--- a/src/components/MobileCarouselWrapper.tsx
+++ b/src/components/MobileCarouselWrapper.tsx
@@ -212,7 +212,7 @@ export const MobileCarouselWrapper: React.FC<MobileCarouselWrapperProps> = ({
         
         {/* Swipe hint - only show on first slide */}
         {renderIndex === 0 && childCount > 1 && (
-          <div className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground/40 animate-pulse pointer-events-none">
+          <div className="absolute right-4 top-1/2 -translate-y-1/2 text-white/20 animate-pulse pointer-events-none">
             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>

--- a/src/components/badges/BadgeDisplay.tsx
+++ b/src/components/badges/BadgeDisplay.tsx
@@ -46,7 +46,7 @@ export const BadgeDisplay = ({
         sizeClasses[size],
         earned 
           ? `${definition.bgColor} ${definition.color} ring-2 ring-offset-2 ring-offset-background` 
-          : 'bg-muted/50 text-white/50 opacity-50 grayscale',
+          : 'bg-white/5 text-white/50 opacity-50 grayscale',
         earned && 'hover:scale-110',
         className
       )}

--- a/src/components/blog/BlogDataPoints.tsx
+++ b/src/components/blog/BlogDataPoints.tsx
@@ -17,7 +17,7 @@ const BlogDataPoints: React.FC<BlogDataPointsProps> = ({
   points 
 }) => {
   return (
-    <div className="bg-muted/50 rounded-xl p-6 mb-8">
+    <div className="bg-white/5 rounded-xl p-6 mb-8">
       <h3 className="text-lg font-semibold text-foreground mb-4">{title}</h3>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {points.map((point, index) => {

--- a/src/components/community/CommunityTabs.tsx
+++ b/src/components/community/CommunityTabs.tsx
@@ -20,7 +20,7 @@ export const CommunityTabs = ({ courseId, moduleId }: CommunityTabsProps) => {
       </div>
       
       <Tabs defaultValue="comments" className="w-full">
-        <TabsList className="mt-6 mb-4 flex flex-wrap justify-center w-full rounded-lg bg-card/60 border border-white/8 p-3 gap-3">
+        <TabsList className="mt-6 mb-4 flex flex-wrap justify-center w-full rounded-lg bg-white/3 border border-white/8 p-3 gap-3">
           <TabsTrigger 
             value="comments" 
             className="inline-flex items-center justify-center gap-2 rounded-md px-5 py-3 min-h-[44px] text-sm font-medium data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=inactive]:bg-transparent data-[state=inactive]:text-white/50 hover:text-foreground transition-colors"

--- a/src/components/landing/GlowCard.tsx
+++ b/src/components/landing/GlowCard.tsx
@@ -64,7 +64,7 @@ const GlowCard = ({
         }}
       />
       
-      <Card className="relative bg-card/80 backdrop-blur-sm border-white/8 hover:border-primary/30 transition-all duration-300 h-full">
+      <Card className="relative bg-white/3 backdrop-blur-sm border-white/8 hover:border-primary/30 transition-all duration-300 h-full">
         {children}
       </Card>
     </div>

--- a/src/components/mini-games/IQTest.tsx
+++ b/src/components/mini-games/IQTest.tsx
@@ -274,7 +274,7 @@ export const IQTest: React.FC<{ onComplete: (iq: number, score: number) => void 
           exit={{ x: -20, opacity: 0 }}
           className="space-y-6"
         >
-          <Card className="p-8 border-2 border-primary/20 bg-card/50 backdrop-blur-sm">
+          <Card className="p-8 border-2 border-primary/20 bg-white/3 backdrop-blur-sm">
             <div className="flex items-start gap-4 mb-6">
               <Brain className="w-8 h-8 text-primary shrink-0 mt-1" />
               <h3 className="text-2xl font-medium leading-tight">

--- a/src/pages/DefiMatured2025.tsx
+++ b/src/pages/DefiMatured2025.tsx
@@ -205,7 +205,7 @@ const DefiMatured2025 = () => {
                 </p>
               </section>
 
-              <div className="bg-muted/50 p-6 rounded-lg border border-white/8 mt-8 text-center">
+              <div className="bg-white/5 p-6 rounded-lg border border-white/8 mt-8 text-center">
                 <div className="flex items-center justify-center gap-2 mb-3">
                   <AlertTriangle className="h-5 w-5 text-yellow-500" />
                   <span className="font-semibold text-foreground">Educational Disclaimer</span>

--- a/src/pages/MiniGames.tsx
+++ b/src/pages/MiniGames.tsx
@@ -322,7 +322,7 @@ const MiniGames = () => {
               </div>
             </div>
 
-            <Card className="p-8 bg-card/50 backdrop-blur-md border-primary/20 overflow-hidden relative min-h-[500px] flex items-center justify-center">
+            <Card className="p-8 bg-white/3 backdrop-blur-md border-primary/20 overflow-hidden relative min-h-[500px] flex items-center justify-center">
               <AnimatePresence mode="wait">
                 {ActiveGameComponent && (
                   <ActiveGameComponent onComplete={handleGameComplete} />


### PR DESCRIPTION
Standardized CSS tokens in 9 files to ensure a consistent dark-mode aesthetic. Replaced legacy theme-dependent tokens (bg-card, bg-muted, bg-background, text-muted-foreground) with direct opacity-based white and black tokens as per the platform's migration strategy. Each file received exactly one token replacement to maintain surgical precision. Verified the changes with a successful build and frontend screenshots.

---
*PR created automatically by Jules for task [995745430335942842](https://jules.google.com/task/995745430335942842) started by @3rdeyeadvisors*