### PR TITLE
Update Admin Emails & Rebrand Dev Standards

### DIFF
--- a/DEVELOPMENT_STANDARDS.md
+++ b/DEVELOPMENT_STANDARDS.md
@@ -1,4 +1,4 @@
-# 3rdEyeAdvisors Development Standards
+# Sentinel DeFi Development Standards
 
 ## Purpose
 This document establishes the systematic workflow for all feature development and bug fixes to ensure:

--- a/supabase/functions/mailchimp-sync/index.ts
+++ b/supabase/functions/mailchimp-sync/index.ts
@@ -106,7 +106,7 @@ const handler = async (req: Request): Promise<Response> => {
           permission_reminder: 'You signed up for updates from Sentinel DeFi',
           campaign_defaults: {
             from_name: 'Sentinel DeFi',
-            from_email: 'info@3rdeyeadvisors.com',
+            from_email: 'info@the3rdeyeadvisors.com',
             subject: '',
             language: 'en'
           },

--- a/supabase/functions/send-broadcast-alert/index.ts
+++ b/supabase/functions/send-broadcast-alert/index.ts
@@ -100,7 +100,7 @@ const handler = async (req: Request): Promise<Response> => {
     // Send alert email
     const { data: emailData, error: emailError } = await resend.emails.send({
       from: 'Sentinel DeFi Alerts <info@the3rdeyeadvisors.com>',
-      to: ['3rdeyeadvisors@gmail.com'],
+      to: ['info@the3rdeyeadvisors.com'],
       subject: '⚠️ Sentinel DeFi Broadcast Issue Detected',
       html: emailHtml,
     });
@@ -128,7 +128,7 @@ const handler = async (req: Request): Promise<Response> => {
     // Log to email_logs
     await supabase.from('email_logs').insert({
       email_type: 'broadcast_alert',
-      recipient_email: '3rdeyeadvisors@gmail.com',
+      recipient_email: 'info@the3rdeyeadvisors.com',
       edge_function_name: 'send-broadcast-alert',
       status: 'sent',
       related_id: payload.alert_id,

--- a/supabase/functions/send-weekly-summary/index.ts
+++ b/supabase/functions/send-weekly-summary/index.ts
@@ -222,7 +222,7 @@ const handler = async (req: Request): Promise<Response> => {
     // Send summary email
     const { data: emailData, error: emailError } = await resend.emails.send({
       from: 'Sentinel DeFi Reports <info@the3rdeyeadvisors.com>',
-      to: ['3rdeyeadvisors@gmail.com'],
+      to: ['info@the3rdeyeadvisors.com'],
       subject: `📊 Sentinel DeFi Broadcast Weekly Summary - ${successRate}% Success Rate`,
       html: emailHtml,
     });
@@ -248,7 +248,7 @@ const handler = async (req: Request): Promise<Response> => {
     // Log to email_logs
     await supabase.from('email_logs').insert({
       email_type: 'weekly_summary',
-      recipient_email: '3rdeyeadvisors@gmail.com',
+      recipient_email: 'info@the3rdeyeadvisors.com',
       edge_function_name: 'send-weekly-summary',
       status: 'sent',
       metadata: {


### PR DESCRIPTION
This PR addresses remaining email configuration issues and updates development standards to reflect current branding.

Key changes:
1. **Edge Functions**: Replaced hardcoded legacy email `3rdeyeadvisors@gmail.com` with the correct admin email `info@the3rdeyeadvisors.com` in both `send-weekly-summary` and `send-broadcast-alert` functions. This affects both email delivery and logging.
2. **Mailchimp Sync**: Updated the default `from_email` in the `mailchimp-sync` function from `info@3rdeyeadvisors.com` to `info@the3rdeyeadvisors.com`.
3. **Documentation**: Updated the main header in `DEVELOPMENT_STANDARDS.md` from "3rdEyeAdvisors Development Standards" to "Sentinel DeFi Development Standards" to align with the platform's rebranding.

---
*PR created automatically by Jules for task [13539542491907579261](https://jules.google.com/task/13539542491907579261) started by @3rdeyeadvisors*