### PR TITLE
Force Instant PWA Updates and Cache Busting

### DIFF
--- a/src/components/pwa/ReloadPrompt.tsx
+++ b/src/components/pwa/ReloadPrompt.tsx
@@ -12,21 +12,16 @@ function ReloadPrompt() {
     },
   });
 
-  // Handle case where useRegisterSW might return undefined or incomplete in some environments
-  if (!swResult || !Array.isArray(swResult.offlineReady) || !Array.isArray(swResult.needRefresh)) {
-    return null;
-  }
-
   const {
-    offlineReady: [offlineReady, setOfflineReady],
-    needRefresh: [needRefresh, setNeedRefresh],
+    offlineReady: [offlineReady, setOfflineReady] = [false, () => {}],
+    needRefresh: [needRefresh, setNeedRefresh] = [false, () => {}],
     updateServiceWorker,
-  } = swResult;
+  } = swResult || {};
 
-  const close = () => {
-    setOfflineReady(false);
-    setNeedRefresh(false);
-  };
+  const close = React.useCallback(() => {
+    if (setOfflineReady) setOfflineReady(false);
+    if (setNeedRefresh) setNeedRefresh(false);
+  }, [setOfflineReady, setNeedRefresh]);
 
   // Automatic update check on focus/visibility change
   React.useEffect(() => {
@@ -44,8 +39,8 @@ function ReloadPrompt() {
       }
     });
 
-    // Check for updates every 60 minutes
-    const interval = setInterval(checkUpdate, 60 * 60 * 1000);
+    // Check for updates every 5 minutes
+    const interval = setInterval(checkUpdate, 5 * 60 * 1000);
 
     return () => {
       window.removeEventListener('focus', checkUpdate);
@@ -75,12 +70,6 @@ function ReloadPrompt() {
     };
   }, []);
 
-  // Check if we are in standalone mode (Home Screen)
-  const isStandalone = React.useMemo(() => {
-    return window.matchMedia('(display-mode: standalone)').matches ||
-           (window.navigator as any).standalone === true;
-  }, []);
-
   React.useEffect(() => {
     if (offlineReady) {
       toast.success("App ready to work offline", {
@@ -90,28 +79,13 @@ function ReloadPrompt() {
         },
       });
     }
-  }, [offlineReady]);
+  }, [offlineReady, close]);
 
   React.useEffect(() => {
     if (needRefresh) {
-      // If in standalone mode, we might want to be more aggressive or automatic
-      if (isStandalone) {
-        updateServiceWorker(true);
-      } else {
-        toast("New content available, click on reload button to update.", {
-          duration: Infinity,
-          action: {
-            label: "Reload",
-            onClick: () => updateServiceWorker(true),
-          },
-          cancel: {
-            label: "Close",
-            onClick: () => close(),
-          }
-        });
-      }
+      updateServiceWorker(true);
     }
-  }, [needRefresh, isStandalone, updateServiceWorker]);
+  }, [needRefresh, updateServiceWorker]);
 
   if (!offlineReady && !needRefresh) return null;
 
@@ -119,23 +93,9 @@ function ReloadPrompt() {
     <div className="fixed bottom-4 right-4 z-[100] p-3 rounded-lg bg-white/3 border border-white/8 shadow-cosmic animate-in fade-in slide-in-from-bottom-4 duration-300">
       <div className="flex flex-col gap-3">
         <div className="text-sm font-consciousness">
-          {offlineReady ? (
-            <span>App ready to work offline</span>
-          ) : (
-            <span>New content available, click on reload button to update.</span>
-          )}
+          <span>App ready to work offline</span>
         </div>
         <div className="flex gap-2">
-          {needRefresh && (
-            <Button
-              size="sm"
-              onClick={() => updateServiceWorker(true)}
-              className="font-consciousness gap-2"
-            >
-              <RefreshCw className="w-4 h-4" />
-              Reload
-            </Button>
-          )}
           <Button
             variant="outline"
             size="sm"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig(({ mode }) => ({
         theme_color: '#0A1628',
         background_color: '#0A1628',
         display: 'standalone',
-        start_url: '/?v=2.1.0',
+        start_url: '/?v=2.2.0',
         scope: '/',
         orientation: 'portrait',
         icons: [
@@ -66,6 +66,7 @@ export default defineConfig(({ mode }) => ({
         // Skip waiting and claim clients immediately for seamless updates
         skipWaiting: true,
         clientsClaim: true,
+        cleanupOutdatedCaches: true,
         maximumFileSizeToCacheInBytes: 10 * 1024 * 1024, // 10 MB limit for large thirdweb bundle
         // Only cache essential static assets
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],


### PR DESCRIPTION
This change forces the PWA to check for updates every 5 minutes and automatically reload the application as soon as a new version is detected. It also includes cache busting via a versioned start_url and automatic cleanup of outdated caches.

---
*PR created automatically by Jules for task [9345226300193618143](https://jules.google.com/task/9345226300193618143) started by @3rdeyeadvisors*