### PR TITLE
Add useSocialLinks and usePageVisibility hooks

### DIFF
--- a/src/hooks/usePageVisibility.tsx
+++ b/src/hooks/usePageVisibility.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface PageVisibility {
+  id: string;
+  path: string;
+  is_visible: boolean;
+  updated_at: string;
+}
+
+export const usePageVisibility = () => {
+  const queryClient = useQueryClient();
+
+  const { data: pages, isLoading, error } = useQuery({
+    queryKey: ['page-visibility'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('page_visibility' as any)
+        .select('*');
+
+      if (error) throw error;
+      return data as unknown as PageVisibility[];
+    },
+  });
+
+  useEffect(() => {
+    const channel = supabase
+      .channel('page-visibility-sync')
+      .on(
+        'postgres_changes' as any,
+        {
+          event: '*',
+          schema: 'public',
+          table: 'page_visibility',
+        },
+        () => {
+          queryClient.invalidateQueries({ queryKey: ['page-visibility'] });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [queryClient]);
+
+  const isPageVisible = (path: string): boolean => {
+    if (!pages) return true; // Fail-open
+    const page = pages.find(p => p.path === path);
+    if (!page) return true; // Fail-open for unknown paths
+    return page.is_visible;
+  };
+
+  return { pages, loading: isLoading, isPageVisible, error };
+};

--- a/src/hooks/useSocialLinks.tsx
+++ b/src/hooks/useSocialLinks.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface SocialLink {
+  id: string;
+  platform: string;
+  label: string;
+  url: string;
+  icon: string;
+  is_active: boolean;
+  sort_order: number;
+  updated_at: string;
+}
+
+export const useSocialLinks = () => {
+  const queryClient = useQueryClient();
+
+  const { data: links, isLoading, error } = useQuery({
+    queryKey: ['social-links'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('social_links' as any)
+        .select('*')
+        .order('sort_order', { ascending: true });
+
+      if (error) throw error;
+      return data as unknown as SocialLink[];
+    },
+  });
+
+  useEffect(() => {
+    const channel = supabase
+      .channel('social-links-sync')
+      .on(
+        'postgres_changes' as any,
+        {
+          event: '*',
+          schema: 'public',
+          table: 'social_links',
+        },
+        () => {
+          queryClient.invalidateQueries({ queryKey: ['social-links'] });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [queryClient]);
+
+  return { links, loading: isLoading, error };
+};


### PR DESCRIPTION
Created two new hooks in `src/hooks/`:
- `useSocialLinks.tsx`: Fetches all rows from the `social_links` table ordered by `sort_order`. It implements a real-time subscription on the `social_links` channel to invalidate the `['social-links']` query on any change. Returns `{ links, loading, error }` and exports the `SocialLink` type.
- `usePageVisibility.tsx`: Fetches all rows from the `page_visibility` table. It implements a real-time subscription on the `page-visibility` channel to invalidate the `['page-visibility']` query on any change. Includes an `isPageVisible(path: string)` helper function that implements fail-open logic (returns `true` for unknown paths or if data is missing). Returns `{ pages, loading, isPageVisible, error }`.

---
*PR created automatically by Jules for task [12993811866454621522](https://jules.google.com/task/12993811866454621522) started by @3rdeyeadvisors*