### PR TITLE
Fix PageVisibility id Bug (Bug 3)

### DIFF
--- a/src/components/admin/SiteControlsManager.tsx
+++ b/src/components/admin/SiteControlsManager.tsx
@@ -259,7 +259,7 @@ export const SiteControlsManager = () => {
 
           <div className="grid gap-3">
             {pages?.map((page) => (
-              <div key={page.id} className="flex items-center justify-between p-4 rounded-xl bg-white/5 border border-white/10 group hover:border-white/20 transition-all">
+              <div key={page.path} className="flex items-center justify-between p-4 rounded-xl bg-white/5 border border-white/10 group hover:border-white/20 transition-all">
                 <div className="flex flex-col">
                   <span className="text-sm font-medium text-white capitalize">
                     {page.path.replace(/^\//, '').replace(/-/g, ' ') || 'Home'}

--- a/src/hooks/usePageVisibility.tsx
+++ b/src/hooks/usePageVisibility.tsx
@@ -3,8 +3,9 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 
 export interface PageVisibility {
-  id: string;
+  id?: number;
   path: string;
+  label?: string;
   is_visible: boolean;
   updated_at: string;
 }


### PR DESCRIPTION
This change fixes a bug related to the `PageVisibility` ID by updating the interface to match the new database schema (SERIAL column) and updating the UI to use the unique `path` as a key for mapping over pages.

---
*PR created automatically by Jules for task [16047986812126132465](https://jules.google.com/task/16047986812126132465) started by @3rdeyeadvisors*