### PR TITLE
Fix colon typo and hardcoded date in EmailHub.tsx

### DIFF
--- a/src/components/admin/EmailHub.tsx
+++ b/src/components/admin/EmailHub.tsx
@@ -138,7 +138,7 @@ const EmailTemplates = () => {
                                 Prize: ${sampleData.prize}
                               </p>
                               <p style="font-size: 16px; margin: 8px 0; color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;">
-                                🕒 Active Period: November 10 to 23, 2025
+                                🕒 Active Period: ${new Date(sampleData.end_date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
                               </p>
                             </div>
                           </td>
@@ -718,7 +718,7 @@ export function EmailHub() {
                           Awareness is advantage.
                         </p>
                         <p style="font-size: 14px; color: #666666; margin: 0; font-family: Arial, sans-serif;">
-                         : Sentinel DeFi
+                         Sentinel DeFi
                         </p>
                       </td>
                     </tr>


### PR DESCRIPTION
This PR applies two surgical fixes to `src/components/admin/EmailHub.tsx`:
1. Removes an erroneous colon before "Sentinel DeFi" in the `getRaffleEmailHTML` function's footer.
2. Updates the `templates.announcement.html` template to use a dynamic date for the "Active Period" instead of a hardcoded one, ensuring it always displays a current-looking date relative to `sampleData.end_date`.

---
*PR created automatically by Jules for task [16143683167498806296](https://jules.google.com/task/16143683167498806296) started by @3rdeyeadvisors*