### PR TITLE
Add CI Build Check Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+      - name: Run Build
+        run: npm run build


### PR DESCRIPTION
This PR implements a safety net to catch build errors before they are merged into the `main` branch.

Key changes:
- Created the `.github/workflows` directory.
- Added a `ci.yml` workflow file named "Build Check".
- The workflow is triggered on `push` and `pull_request` to the `main` branch.
- It uses Node.js 20 and runs `npm install --legacy-peer-deps` followed by `npm run build`.
- Local verification confirmed that `npm run build` passes with the `--legacy-peer-deps` flag.

---
*PR created automatically by Jules for task [315556255330277904](https://jules.google.com/task/315556255330277904) started by @3rdeyeadvisors*