### PR TITLE
Fix Brain Games Glitches, Instructions, and Scrolling Issues

### DIFF
--- a/src/components/mini-games/GameIntro.tsx
+++ b/src/components/mini-games/GameIntro.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { motion } from 'framer-motion';
+import { LucideIcon } from 'lucide-react';
+
+interface GameIntroProps {
+  title: string;
+  description: string;
+  instructions: string[];
+  icon: LucideIcon;
+  onStart: () => void;
+}
+
+export const GameIntro: React.FC<GameIntroProps> = ({
+  title,
+  description,
+  instructions,
+  icon: Icon,
+  onStart,
+}) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      className="text-center space-y-6 max-w-sm mx-auto p-4"
+    >
+      <div className="w-20 h-20 bg-primary/20 rounded-full flex items-center justify-center mx-auto mb-4">
+        <Icon className="w-10 h-10 text-primary" />
+      </div>
+      <h3 className="text-3xl font-bold font-consciousness tracking-tight">{title}</h3>
+      <p className="text-white/60 text-sm leading-relaxed">{description}</p>
+
+      <div className="bg-white/5 rounded-xl p-4 text-left border border-white/10">
+        <h4 className="text-xs font-bold text-primary uppercase tracking-widest mb-3">How to play:</h4>
+        <ul className="space-y-2">
+          {instructions.map((step, idx) => (
+            <li key={idx} className="text-sm text-white/80 flex gap-3">
+              <span className="text-primary font-bold">{idx + 1}.</span>
+              {step}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Button onClick={onStart} size="lg" className="w-full bg-primary hover:bg-primary/90 text-white font-bold py-6 rounded-xl shadow-lg shadow-primary/20 transition-all hover:scale-[1.02] active:scale-[0.98]">
+        Start Training
+      </Button>
+    </motion.div>
+  );
+};

--- a/src/components/mini-games/GridFocus.tsx
+++ b/src/components/mini-games/GridFocus.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
 import { Target, Trophy, Timer } from 'lucide-react';
 import { toast } from "sonner";
+import { GameIntro } from './GameIntro';
 
 export const GridFocus: React.FC<{ onComplete: (score: number) => void }> = ({ onComplete }) => {
   const { playClick, playSuccess, playError } = useAchievementSounds();
@@ -70,16 +71,31 @@ export const GridFocus: React.FC<{ onComplete: (score: number) => void }> = ({ o
     onComplete(score);
   };
 
+  const resetGame = () => {
+    setGridSize(3);
+    setTargetNumber(1);
+    setNumbers([]);
+    setTimeLeft(30);
+    setScore(0);
+    setIsGameOver(false);
+    setIsStarted(true);
+    generateGrid();
+  };
+
   if (!isStarted) {
     return (
-      <div className="text-center space-y-6 max-w-sm">
-        <Target className="w-16 h-16 text-primary mx-auto" />
-        <h3 className="text-2xl font-bold font-consciousness">Grid Focus</h3>
-        <p className="text-white/60 text-sm">
-          Click the numbers in order from 1 to {gridSize * gridSize}. How many grids can you clear?
-        </p>
-        <Button onClick={handleStart} className="w-full">Start Game</Button>
-      </div>
+      <GameIntro
+        title="Grid Focus"
+        description="Enhance peripheral vision and visual search speed by locating numbers in sequence."
+        icon={Target}
+        instructions={[
+          `Locate and click numbers in sequence from 1 to ${gridSize * gridSize}.`,
+          "The grid will expand as you progress.",
+          "Speed is rewarded with bonus points.",
+          "Complete as many grids as possible before time runs out."
+        ]}
+        onStart={handleStart}
+      />
     );
   }
 
@@ -89,7 +105,7 @@ export const GridFocus: React.FC<{ onComplete: (score: number) => void }> = ({ o
         <Trophy className="w-16 h-16 text-yellow-500 mx-auto glow-yellow" />
         <h3 className="text-2xl font-bold font-consciousness">Time's Up!</h3>
         <p className="text-4xl font-bold text-primary">{score} Points</p>
-        <Button onClick={() => window.location.reload()}>Try Again</Button>
+        <Button onClick={resetGame}>Try Again</Button>
       </div>
     );
   }

--- a/src/components/mini-games/IQTest.tsx
+++ b/src/components/mini-games/IQTest.tsx
@@ -8,6 +8,7 @@ import { shareResultsViaEmail } from '@/lib/email';
 import { useAuth } from '@/components/auth/AuthProvider';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
 import { toast } from 'sonner';
+import { GameIntro } from './GameIntro';
 
 interface IQQuestion {
   id: number;
@@ -132,6 +133,7 @@ export const IQTest: React.FC<{ onComplete: (iq: number, score: number) => void 
   const [currentStep, setCurrentStep] = useState(0);
   const [answers, setAnswers] = useState<number[]>([]);
   const [isFinished, setIsFinished] = useState(false);
+  const [isStarted, setIsStarted] = useState(false);
   const [isSending, setIsSending] = useState(false);
 
   const handleAnswer = (optionIndex: number) => {
@@ -202,6 +204,23 @@ export const IQTest: React.FC<{ onComplete: (iq: number, score: number) => void 
     });
     setIsSending(false);
   };
+
+  if (!isStarted) {
+    return (
+      <GameIntro
+        title="IQ Assessment"
+        description="A comprehensive evaluation of your logical, mathematical, and spatial reasoning skills."
+        icon={Brain}
+        instructions={[
+          "There are 15 questions in total.",
+          "Questions cover patterns, logic, math, and spatial awareness.",
+          "Think carefully before selecting an answer.",
+          "Your estimated IQ will be calculated at the end."
+        ]}
+        onStart={() => setIsStarted(true)}
+      />
+    );
+  }
 
   if (isFinished) {
     const finalIQ = 70 + (answers.filter((ans, idx) => ans === QUESTIONS[idx].correct).length * 5.33);

--- a/src/components/mini-games/MathSprint.tsx
+++ b/src/components/mini-games/MathSprint.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Timer, Zap, CheckCircle2, XCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
+import { GameIntro } from './GameIntro';
 
 interface Problem {
   text: string;
@@ -92,6 +93,23 @@ export const MathSprint: React.FC<{ onComplete: (score: number) => void }> = ({ 
     }
   };
 
+  if (gameState === 'idle') {
+    return (
+      <GameIntro
+        title="Math Sprint"
+        description="Fast-paced mental arithmetic to sharpen your fluid intelligence and speed."
+        icon={Timer}
+        instructions={[
+          "Solve as many math problems as you can before time runs out.",
+          "Type your answer and press Enter.",
+          "Correct answers increase your score.",
+          "The game lasts for 30 seconds."
+        ]}
+        onStart={startGame}
+      />
+    );
+  }
+
   return (
     <div className="flex flex-col items-center gap-6 p-4 w-full max-w-md mx-auto">
       <div className="flex justify-between w-full items-center px-2">
@@ -116,12 +134,6 @@ export const MathSprint: React.FC<{ onComplete: (score: number) => void }> = ({ 
             </motion.div>
           )}
         </AnimatePresence>
-
-        {gameState === 'idle' && (
-          <Button onClick={startGame} size="lg" className="gap-2">
-            <Zap className="w-5 h-5" /> Start Math Sprint
-          </Button>
-        )}
 
         {gameState === 'playing' && problem && (
           <motion.form

--- a/src/components/mini-games/MemoryMatch.tsx
+++ b/src/components/mini-games/MemoryMatch.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Brain, RefreshCw } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
+import { GameIntro } from './GameIntro';
 
 interface MemoryCard {
   id: number;
@@ -20,6 +21,7 @@ export const MemoryMatch: React.FC<{ onComplete: (score: number) => void }> = ({
   const [flippedCards, setFlippedCards] = useState<number[]>([]);
   const [moves, setMoves] = useState(0);
   const [isWon, setIsWon] = useState(false);
+  const [isStarted, setIsStarted] = useState(false);
 
   const initGame = useCallback(() => {
     const shuffled = [...SYMBOLS, ...SYMBOLS]
@@ -37,8 +39,10 @@ export const MemoryMatch: React.FC<{ onComplete: (score: number) => void }> = ({
   }, []);
 
   useEffect(() => {
-    initGame();
-  }, [initGame]);
+    if (isStarted) {
+      initGame();
+    }
+  }, [isStarted, initGame]);
 
   const handleCardClick = (id: number) => {
     if (flippedCards.length === 2 || cards[id].isFlipped || cards[id].isMatched || isWon) return;
@@ -79,6 +83,23 @@ export const MemoryMatch: React.FC<{ onComplete: (score: number) => void }> = ({
       }
     }
   };
+
+  if (!isStarted) {
+    return (
+      <GameIntro
+        title="Memory Match"
+        description="Strengthen short-term memory and visual focus by matching pairs of symbols."
+        icon={Brain}
+        instructions={[
+          "Click a card to reveal its symbol.",
+          "Click another card to find its match.",
+          "If they match, they stay flipped.",
+          "Match all pairs in as few moves as possible."
+        ]}
+        onStart={() => setIsStarted(true)}
+      />
+    );
+  }
 
   return (
     <div className="flex flex-col items-center gap-6 p-4">

--- a/src/components/mini-games/PatternSequence.tsx
+++ b/src/components/mini-games/PatternSequence.tsx
@@ -2,6 +2,8 @@ import React, { useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { motion } from 'framer-motion';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
+import { GameIntro } from './GameIntro';
+import { Target } from 'lucide-react';
 
 const COLORS = [
   { id: 0, color: 'bg-red-500', glow: 'shadow-[0_0_20px_#ef4444]' },
@@ -71,6 +73,23 @@ export const PatternSequence: React.FC<{ onComplete: (score: number) => void }> 
     startNextLevel([]);
   };
 
+  if (gameState === 'idle') {
+    return (
+      <GameIntro
+        title="Pattern Sequence"
+        description="Enhance focus and sequence recognition by following a growing pattern of colors and sounds."
+        icon={Target}
+        instructions={[
+          "Watch the sequence of colors as they light up.",
+          "Repeat the sequence by clicking the colors in the same order.",
+          "The sequence grows by one color each level.",
+          "See how many levels you can complete without a mistake."
+        ]}
+        onStart={startGame}
+      />
+    );
+  }
+
   return (
     <div className="flex flex-col items-center gap-8 p-4 w-full max-w-md mx-auto">
       <div className="text-2xl font-consciousness text-primary">Level: {level}</div>
@@ -93,9 +112,6 @@ export const PatternSequence: React.FC<{ onComplete: (score: number) => void }> 
       </motion.div>
 
       <div className="text-center h-12 flex items-center justify-center">
-        {gameState === 'idle' && (
-          <Button onClick={startGame} size="lg">Start Pattern Test</Button>
-        )}
         {gameState === 'showing' && <p className="text-lg text-primary animate-pulse">Watch the pattern...</p>}
         {gameState === 'playing' && <p className="text-lg text-primary">Your turn!</p>}
         {gameState === 'gameOver' && (

--- a/src/components/mini-games/ReactionTime.tsx
+++ b/src/components/mini-games/ReactionTime.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Zap, Clock, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
+import { GameIntro } from './GameIntro';
 
 export const ReactionTime: React.FC<{ onComplete: (score: number) => void }> = ({ onComplete }) => {
   const { playSuccess, playWrongAnswer, playClick } = useAchievementSounds();
@@ -67,6 +68,23 @@ export const ReactionTime: React.FC<{ onComplete: (score: number) => void }> = (
       default: return 'bg-white/3 border-white/8';
     }
   };
+
+  if (gameState === 'idle') {
+    return (
+      <GameIntro
+        title="Reaction Test"
+        description="Improve mental agility and physical reflex speed with this lightning-fast challenge."
+        icon={Zap}
+        instructions={[
+          "Click the screen once to start the timer.",
+          "Wait for the red background to turn blue.",
+          "Click as FAST as you can when you see blue!",
+          "Don't click too early, or you'll have to restart."
+        ]}
+        onStart={startTest}
+      />
+    );
+  }
 
   return (
     <div className="flex flex-col items-center gap-6 p-4 w-full max-w-md mx-auto">

--- a/src/components/mini-games/StroopEffect.tsx
+++ b/src/components/mini-games/StroopEffect.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/card';
 import { Brain, Trophy, Zap, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
+import { GameIntro } from './GameIntro';
 
 const COLORS = ["#EF4444", "#3B82F6", "#10B981", "#F59E0B"];
 const COLOR_NAMES = ["RED", "BLUE", "GREEN", "YELLOW"];
@@ -60,16 +61,28 @@ export const StroopEffect: React.FC<{ onComplete: (score: number) => void }> = (
     onComplete(score);
   };
 
+  const resetGame = () => {
+    setScore(0);
+    setTimeLeft(30);
+    setIsGameOver(false);
+    setIsStarted(true);
+    nextChallenge();
+  };
+
   if (!isStarted) {
     return (
-      <div className="text-center space-y-6 max-w-sm">
-        <Zap className="w-16 h-16 text-yellow-500 mx-auto" />
-        <h3 className="text-2xl font-bold font-consciousness">Stroop Test</h3>
-        <p className="text-white/60 text-sm">
-          Select the color of the text, NOT what the word says. Speed and accuracy matter!
-        </p>
-        <Button onClick={handleStart} className="w-full">Start Game</Button>
-      </div>
+      <GameIntro
+        title="Stroop Test"
+        description="Overcome cognitive interference by identifying the color of the text rather than reading the word itself."
+        icon={Zap}
+        instructions={[
+          "Look at the word displayed in the center.",
+          "Identify the actual color of the font.",
+          "Ignore what the word says.",
+          "Click the button corresponding to the font color as fast as possible."
+        ]}
+        onStart={handleStart}
+      />
     );
   }
 
@@ -79,7 +92,7 @@ export const StroopEffect: React.FC<{ onComplete: (score: number) => void }> = (
         <Trophy className="w-16 h-16 text-yellow-500 mx-auto glow-yellow" />
         <h3 className="text-2xl font-bold font-consciousness">Test Complete</h3>
         <p className="text-4xl font-bold text-primary">{score} Points</p>
-        <Button onClick={() => window.location.reload()}>Try Again</Button>
+        <Button onClick={resetGame}>Try Again</Button>
       </div>
     );
   }

--- a/src/components/mini-games/WordMemory.tsx
+++ b/src/components/mini-games/WordMemory.tsx
@@ -5,6 +5,7 @@ import { Progress } from '@/components/ui/progress';
 import { Brain, Trophy, Timer, RefreshCw } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAchievementSounds } from '@/hooks/useAchievementSounds';
+import { GameIntro } from './GameIntro';
 
 const WORDS = [
   "CRYPTO", "BLOCK", "CHAIN", "TOKEN", "STAKE", "YIELD", "MINER", "WALLET",
@@ -15,10 +16,12 @@ export const WordMemory: React.FC<{ onComplete: (score: number) => void }> = ({ 
   const { playClick, playSuccess, playError } = useAchievementSounds();
   const [sequence, setSequence] = useState<string[]>([]);
   const [isShowing, setIsShowing] = useState(true);
+  const [displayIndex, setDisplayIndex] = useState(0);
   const [currentIndex, setCurrentStep] = useState(0);
   const [level, setLevel] = useState(1);
   const [score, setScore] = useState(0);
   const [isGameOver, setIsGameOver] = useState(false);
+  const [isStarted, setIsStarted] = useState(false);
 
   const startLevel = useCallback(() => {
     const newSequence = [];
@@ -27,17 +30,29 @@ export const WordMemory: React.FC<{ onComplete: (score: number) => void }> = ({ 
     }
     setSequence(newSequence);
     setIsShowing(true);
+    setDisplayIndex(0);
     setCurrentStep(0);
-
-    // Show each word for 1.5 seconds
-    setTimeout(() => {
-      setIsShowing(false);
-    }, (level + 2) * 1500);
   }, [level]);
 
   useEffect(() => {
-    startLevel();
-  }, [level, startLevel]);
+    if (isStarted) {
+      startLevel();
+    }
+  }, [level, startLevel, isStarted]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (isShowing && sequence.length > 0) {
+      if (displayIndex < sequence.length) {
+        timer = setTimeout(() => {
+          setDisplayIndex(prev => prev + 1);
+        }, 1500);
+      } else {
+        setIsShowing(false);
+      }
+    }
+    return () => clearTimeout(timer);
+  }, [isShowing, displayIndex, sequence.length]);
 
   const handleWordClick = (word: string) => {
     if (isShowing || isGameOver) return;
@@ -66,13 +81,37 @@ export const WordMemory: React.FC<{ onComplete: (score: number) => void }> = ({ 
     onComplete(score);
   };
 
+  const resetGame = () => {
+    setLevel(1);
+    setScore(0);
+    setIsGameOver(false);
+    startLevel();
+  };
+
+  if (!isStarted) {
+    return (
+      <GameIntro
+        title="Word Chain"
+        description="Test your verbal memory and auditory loops with complex sequences of DeFi-related terms."
+        icon={Brain}
+        instructions={[
+          "Observe the sequence of words carefully as they appear.",
+          "Once the sequence ends, click the words in the exact same order.",
+          "The sequence gets longer with each level.",
+          "A single mistake ends the game."
+        ]}
+        onStart={() => setIsStarted(true)}
+      />
+    );
+  }
+
   if (isGameOver) {
     return (
       <div className="text-center space-y-6">
         <Trophy className="w-16 h-16 text-yellow-500 mx-auto glow-yellow" />
         <h3 className="text-2xl font-bold font-consciousness">Game Over</h3>
         <p className="text-4xl font-bold text-primary">{score} Points</p>
-        <Button onClick={() => window.location.reload()}>Try Again</Button>
+        <Button onClick={resetGame}>Try Again</Button>
       </div>
     );
   }
@@ -94,14 +133,13 @@ export const WordMemory: React.FC<{ onComplete: (score: number) => void }> = ({ 
         <AnimatePresence mode="wait">
           {isShowing ? (
             <motion.div
-              key={`word-${currentIndex}`}
+              key={`word-${displayIndex}`}
               initial={{ y: 20, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
               exit={{ y: -20, opacity: 0 }}
               className="text-4xl font-bold text-white tracking-widest"
             >
-              {sequence[Math.floor((Date.now() % (sequence.length * 1500)) / 1500)] || sequence[0]}
-              {/* Note: This is a simplification for the demo, real logic would use a timer for sequential display */}
+              {sequence[displayIndex]}
             </motion.div>
           ) : (
             <div className="text-center">

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -30,6 +30,11 @@ const AdminDashboard = () => {
     return () => clearInterval(timer);
   }, []);
 
+  // Scroll to top when switching sections
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, [activeSection]);
+
   const checkAdminStatus = async () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();

--- a/src/pages/MiniGames.tsx
+++ b/src/pages/MiniGames.tsx
@@ -198,6 +198,11 @@ const MiniGames = () => {
 
   const ActiveGameComponent = GAMES.find(g => g.id === activeGame)?.component;
 
+  // Scroll to top when switching between game list and an active game
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, [activeGame]);
+
   return (
     <>
       <SEO


### PR DESCRIPTION
This PR addresses several user-reported issues:
1. **Scrolling Issue**: Fixed the annoying behavior where switching games or dashboard sections would leave the user at the bottom of the page. This was achieved by adding explicit scroll-to-top effects for internal state changes that don't trigger a route change.
2. **Brain Game Glitches**: The "white screen" glitches in games like Word Memory were traced to brittle render-time calculations. These have been refactored to use proper React state and timers.
3. **Missing Instructions**: Created a new `GameIntro` component and integrated it into all mini-games, providing clear "How to play" directions before any game starts.
4. **Platform Reliability**: Cleaned up legacy `window.location.reload()` calls in games to ensure the platform remains a smooth Single Page Application experience.

---
*PR created automatically by Jules for task [12612577112174787669](https://jules.google.com/task/12612577112174787669) started by @3rdeyeadvisors*